### PR TITLE
Canvas encapsulate

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@
   - Disable node popup menus
   - Lock the canvas' position
   - Lock the canvas' zoom
+- [Encapsulate selection](#encapsulate-selection)
+  - Create a new canvas from the selected nodes
+  - Create a link to the new canvas in the current canvas
 - Expose [canvas events](#canvas-events) to use them in other plugins
 - Expose node data to style them using CSS
 
@@ -149,6 +152,15 @@ In presentation mode, you can navigate through the nodes using the arrow keys. T
 
 ### Usage
 - Use the [updated control menu](#canvas-control-menu) to toggle the new features (Only shown if the canvas is in readonly mode)
+
+## Encapsulate Selection
+- Create a new canvas from the selected nodes
+- Create a link to the new canvas in the current canvas
+
+### Usage
+- Select the nodes you want to encapsulate
+- Use the context menu (right click) to encapsulate the selection
+- OR use the command palette (`Advanced Canvas: Encapsulate selection`)
 
 ## Canvas Events
 All custom events are prefixed with `advanced-canvas:` and can be listened to using `app.workspace.on` (Just like the default events).

--- a/src/@types/Canvas.d.ts
+++ b/src/@types/Canvas.d.ts
@@ -1,8 +1,13 @@
+import { TFile } from "obsidian"
+
 export interface Canvas {
+  view: CanvasView
+
   data: CanvasData
+  getData(): CanvasData
+
   nodes: Map<string, CanvasNode>
   menu: PopupMenu
-  selection: Set<CanvasNode>
   nodeInteractionLayer: NodeInteractionLayer
 
   wrapperEl: HTMLElement
@@ -21,12 +26,17 @@ export interface Canvas {
   readonly: boolean
   setReadonly(readonly: boolean): void
 
-  getData(): CanvasData
+  selection: Set<CanvasNode>
+  getSelectionData(): { nodes: CanvasNodeData[], edges: CanvasEdgeData[], center: Position }
+  deselectAll(): void
 
   getEdgesForNode(node: CanvasNode): CanvasEdge[]
+
   createGroupNode(options: GroupNodeOptions): CanvasNode
+  createFileNode(options: FileNodeOptions): CanvasNode
+  removeNode(node: CanvasNode): void
+
   dragTempNode(dragEvent: any, nodeSize: Size, onDropped: (position: Position) => void): void
-  deselectAll(): void
 
   setViewport(tx: number, ty: number, tZoom: number): void
   markViewportChanged(): void
@@ -36,6 +46,7 @@ export interface Canvas {
 
   undo(): void
   redo(): void
+
   handlePaste(): void
   requestPushHistory(data: CanvasData): void
   requestSave(): void
@@ -45,6 +56,10 @@ export interface Canvas {
   lockedY: number
   lockedZoom: number
   setNodeUnknownData(node: CanvasNode, key: string, value: any): void
+}
+
+export interface CanvasView {
+  file: TFile
 }
 
 export interface Size {
@@ -64,18 +79,30 @@ export interface BBox {
   maxY: number
 }
 
-export interface GroupNodeOptions {
+type Side = 'top' | 'right' | 'bottom' | 'left'
+
+export interface NodeOptions {
   pos: Position
   size: Size
-  label?: string
   save?: boolean
   focus?: boolean
+}
+
+export interface GroupNodeOptions extends NodeOptions {
+  label?: string
+}
+
+export interface FileNodeOptions extends NodeOptions {
+  file: TFile
+  subpath?: string
 }
 
 export interface CanvasData {
   nodes: CanvasNode[]
   edges: CanvasEdge[]
 }
+
+export interface CanvasNodeData extends CanvasNodeUnknownData {}
 
 export interface CanvasNode {
   canvas: Canvas
@@ -93,6 +120,17 @@ export interface CanvasNodeUnknownData {
 }
 
 export type CanvasNodeType = 'text' | 'group' | 'file'
+
+export interface CanvasEdgeData {
+  fromNode: string
+  toNode: string
+
+  fromSide: Side
+  toSide: Side
+
+  id: string
+  label?: string
+}
 
 export interface CanvasEdge {
   label: string

--- a/src/@types/Obsidian.d.ts
+++ b/src/@types/Obsidian.d.ts
@@ -1,12 +1,30 @@
 export * from "obsidian"
 
 declare module "obsidian" {
-  type CustomWorkspace = Workspace & {
-    on(name: string, callback: (...args: any) => void): EventRef
-  }
-
   export default interface App {
-    workspace: CustomWorkspace
+    /** @public */
+    keymap: Keymap;
+    /** @public */
+    scope: Scope;
+
+    /** @public */
+    vault: Vault;
+    /** @public */
+    metadataCache: MetadataCache;
+
+    /** @public */
+    fileManager: FileManager;
+
+    /**
+     * The last known user interaction event, to help commands find out what modifier keys are pressed.
+     * @public
+     */
+    lastEvent: UserEvent | null;
+
+    /** @public */
+    workspace:  Workspace & {
+      on(name: string, callback: (...args: any) => void): EventRef
+    }
   }
 
   export interface EventRef {

--- a/src/canvas-extensions/encapsulate-canvas-extension.ts
+++ b/src/canvas-extensions/encapsulate-canvas-extension.ts
@@ -46,7 +46,6 @@ export default class EncapsulateCanvasExtension {
     const sourceFileFolder = canvas.view.file.parent?.path
     if (!sourceFileFolder) return // Should never happen
 
-    // TODO: Check if file already exists
     const targetFilePath = await FileNameModal.awaitInput(new FileNameModal(
       this.plugin.app,
       sourceFileFolder,

--- a/src/canvas-extensions/encapsulate-canvas-extension.ts
+++ b/src/canvas-extensions/encapsulate-canvas-extension.ts
@@ -16,8 +16,8 @@ export default class EncapsulateCanvasExtension {
 
     /* Add command to encapsulate selection */
     this.plugin.addCommand({
-      id: 'encapsulate-canvas',
-      name: 'Encapsulate canvas',
+      id: 'encapsulate-selection',
+      name: 'Encapsulate selection',
       checkCallback: CanvasHelper.canvasCommand(
         this.plugin,
         (canvas: Canvas) => !canvas.readonly && canvas.selection.size > 0,

--- a/src/canvas-extensions/encapsulate-canvas-extension.ts
+++ b/src/canvas-extensions/encapsulate-canvas-extension.ts
@@ -63,7 +63,10 @@ export default class EncapsulateCanvasExtension {
 
     // Add link to new file in current canvas
     canvas.createFileNode({
-      pos: selection.center,
+      pos: {
+        x: selection.center.x - ENCAPSULATED_FILE_NODE_SIZE.width / 2,
+        y: selection.center.y - ENCAPSULATED_FILE_NODE_SIZE.height / 2
+      },
       size: ENCAPSULATED_FILE_NODE_SIZE,
       file: file
     })

--- a/src/canvas-extensions/encapsulate-canvas-extension.ts
+++ b/src/canvas-extensions/encapsulate-canvas-extension.ts
@@ -1,0 +1,52 @@
+import { Menu } from "obsidian"
+import { Canvas } from "src/@types/Canvas"
+import AdvancedCanvasPlugin from "src/main"
+
+const ENCAPSULATED_FILE_NODE_SIZE = { width: 300, height: 300 }
+
+export default class EncapsulateCanvasExtension {
+  plugin: AdvancedCanvasPlugin
+
+  constructor(plugin: AdvancedCanvasPlugin) {
+    this.plugin = plugin
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'canvas:selection-menu',
+      (menu: Menu, canvas: Canvas) => {
+        menu.addItem((item) =>
+          item
+            .setTitle('Encapsulate')
+            .setIcon('file-plus')
+            .onClick(() => this.encapsulateSelection(canvas))
+        )
+      }
+    ))
+  }
+
+  async encapsulateSelection(canvas: Canvas) {
+    const selection = canvas.getSelectionData()
+
+    // Create new file
+    const sourceFileFolder = canvas.view.file.parent?.path
+    if (!sourceFileFolder) return // Should never happen
+
+    // TODO: Check if file already exists
+    const targetFilePath = `${sourceFileFolder}/${canvas.view.file.basename} - Encapsulated.canvas`
+
+    const newFileData = { nodes: selection.nodes, edges: selection.edges }
+    const file = await this.plugin.app.vault.create(targetFilePath, JSON.stringify(newFileData, null, 2))
+
+    // Remove from current canvas
+    for (const nodeData of selection.nodes) {
+      const node = canvas.nodes.get(nodeData.id)
+      if (node) canvas.removeNode(node)
+    }
+
+    // Add link to new file in current canvas
+    canvas.createFileNode({
+      pos: selection.center,
+      size: ENCAPSULATED_FILE_NODE_SIZE,
+      file: file
+    })
+  }
+}

--- a/src/canvas-extensions/presentation-canvas-extension.ts
+++ b/src/canvas-extensions/presentation-canvas-extension.ts
@@ -22,39 +22,41 @@ export default class PresentationCanvasExtension {
     this.plugin.addCommand({
 			id: 'create-new-slide',
 			name: 'Create new slide',
-			checkCallback: this.canvasCommand((canvas: Canvas) => this.addSlide(canvas))
+			checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && !this.isPresentationMode,
+        (canvas: Canvas) => this.addSlide(canvas)
+      )
     })
 
     this.plugin.addCommand({
 			id: 'start-presentation',
       name: 'Start presentation',
-      checkCallback: this.canvasCommand((canvas: Canvas) => this.startPresentation(canvas))
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin, 
+        (_canvas: Canvas) => !this.isPresentationMode,
+        (canvas: Canvas) => this.startPresentation(canvas)
+      )
     })
 
     this.plugin.addCommand({
       id: 'previous-node',
       name: 'Previous node',
-      checkCallback: (checking: boolean) => {
-        const canvas = this.plugin.getCurrentCanvas()
-        if (checking) return canvas !== null && this.isPresentationMode
-
-        if (canvas) this.previousNode(canvas)
-
-        return true
-      }
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (_canvas: Canvas) => this.isPresentationMode,
+        (canvas: Canvas) => this.previousNode(canvas)
+      )
     })
 
     this.plugin.addCommand({
 			id: 'next-node',
       name: 'Next node',
-      checkCallback: (checking: boolean) => {
-        const canvas = this.plugin.getCurrentCanvas()
-        if (checking) return canvas !== null && this.isPresentationMode
-
-        if (canvas) this.nextNode(canvas)
-
-        return true
-      }
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (_canvas: Canvas) => this.isPresentationMode,
+        (canvas: Canvas) => this.nextNode(canvas)
+      )
     })
 
     // Register events
@@ -67,17 +69,6 @@ export default class PresentationCanvasExtension {
       CanvasEvent.PopupMenuCreated,
       (canvas: Canvas) => this.onPopupMenuCreated(canvas)
     ))
-  }
-
-  canvasCommand(callback: (canvas: Canvas) => void): (checking: boolean) => boolean {
-    return (checking: boolean) => {
-      const canvas = this.plugin.getCurrentCanvas()
-      if (checking) return canvas !== null
-
-      if (canvas) callback(canvas)
-
-      return true
-    }
   }
 
   onCanvasChanged(canvas: Canvas): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,12 +8,14 @@ import NodeDataTaggerCanvasExtension from './canvas-extensions/node-data-tagger-
 import CanvasEventEmitter from './events/canvas-event-emitter'
 import { Canvas } from './@types/Canvas'
 import ReadonlyCanvasExtension from './canvas-extensions/readonly-canvas-extension'
+import EncapsulateCanvasExtension from './canvas-extensions/encapsulate-canvas-extension'
 
 const CANVAS_EXTENSIONS: any[] = [
   NodeDataTaggerCanvasExtension,
   InteractionTaggerCanvasExtension,
   ReadonlyCanvasExtension,
   GroupCanvasExtension,
+  EncapsulateCanvasExtension,
   ShapesCanvasExtension,
   PresentationCanvasExtension,
 ]

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -20,6 +20,8 @@ export interface AdvancedCanvasPluginSettings {
   zoomToSlideWithoutPadding: boolean
   slideTransitionAnimationDuration: number
   slideTransitionAnimationIntensity: number
+
+  canvasEncapsulationEnabled: boolean
 }
 
 export const DEFAULT_SETTINGS: Partial<AdvancedCanvasPluginSettings> = {
@@ -36,6 +38,8 @@ export const DEFAULT_SETTINGS: Partial<AdvancedCanvasPluginSettings> = {
   zoomToSlideWithoutPadding: true,
   slideTransitionAnimationDuration: 0.5,
   slideTransitionAnimationIntensity: 1.25,
+
+  canvasEncapsulationEnabled: true,
 }
 
 export default class AdvancedCanvasSettingsManager {
@@ -198,6 +202,17 @@ export class AdvancedCanvasPluginSettingTab extends PluginSettingTab {
         text
           .setValue(this.settingsManager.getSetting('slideTransitionAnimationIntensity').toString())
           .onChange(async (value) => await this.settingsManager.setSetting({ slideTransitionAnimationIntensity: parseFloat(value) }))
+      )
+
+    new Setting(containerEl)
+      .setHeading()
+      .setName("Canvas encapsulation")
+      .setDesc("Encapsulate a selection of nodes and edges into a new canvas.")
+      .addToggle((toggle) =>
+        toggle
+          .setTooltip("Requires a reload to take effect.")
+          .setValue(this.settingsManager.getSetting('canvasEncapsulationEnabled'))
+          .onChange(async (value) => await this.settingsManager.setSetting({ canvasEncapsulationEnabled: value }))
       )
   }
 }

--- a/src/utils/canvas-helper.ts
+++ b/src/utils/canvas-helper.ts
@@ -1,5 +1,6 @@
 import { setIcon, setTooltip } from "obsidian"
 import { BBox, Canvas, Position, Size } from "src/@types/Canvas"
+import AdvancedCanvasPlugin from "src/main"
 
 export function scaleBBox(bbox: BBox, scale: number): BBox {
   let diffX = (scale - 1) * (bbox.maxX - bbox.minX)
@@ -10,6 +11,17 @@ export function scaleBBox(bbox: BBox, scale: number): BBox {
     maxX: bbox.maxX + diffX / 2,
     minY: bbox.minY - diffY / 2,
     maxY: bbox.maxY + diffY / 2
+  }
+}
+
+export function canvasCommand(plugin: AdvancedCanvasPlugin, check: (canvas: Canvas) => boolean, run: (canvas: Canvas) => void): (checking: boolean) => boolean {
+  return (checking: boolean) => {
+    const canvas = plugin.getCurrentCanvas()
+    if (checking) return canvas !== null && check(canvas)
+
+    if (canvas) run(canvas)
+
+    return true
   }
 }
 

--- a/src/utils/modal-helper.ts
+++ b/src/utils/modal-helper.ts
@@ -1,0 +1,38 @@
+import App, { SuggestModal } from "obsidian"
+
+export default class FileNameModal extends SuggestModal<string> {
+  parentPath: string
+  fileExtension: string
+
+  constructor(app: App, parentPath: string, fileExtension: string) {
+    super(app)
+
+    this.parentPath = parentPath
+    this.fileExtension = fileExtension
+  }
+
+  getSuggestions(query: string): string[] {
+    const queryWithoutExtension = query.replace(new RegExp(`\\.${this.fileExtension}$`), '')
+    if (queryWithoutExtension === '') return []
+
+    const queryWithExtension = queryWithoutExtension + '.' + this.fileExtension
+    const suggestions = [`${this.parentPath}/${queryWithExtension}`, queryWithExtension]
+      // Filter out suggestions for files that already exist
+      .filter(s => this.app.vault.getAbstractFileByPath(s) === null)
+
+    return suggestions
+  }
+
+  renderSuggestion(text: string, el: HTMLElement) {
+    el.setText(text)
+  }
+
+  onChooseSuggestion(_text: string, _evt: MouseEvent | KeyboardEvent) {}
+
+  static awaitInput(modal: FileNameModal): Promise<string> {
+    return new Promise((resolve, _reject) => {
+      modal.onChooseSuggestion = (text: string) => { resolve(text) }
+      modal.open()
+    })
+  }
+}


### PR DESCRIPTION
- Move the current selection to a new canvas and create a link in the current canvas
- Adds an option to the selection context menu to encapsulate the selection
- Adds a command to encapsulate the selection