### PR TITLE
fix: deep copy of style attributes for node clone (fixes #287)

### DIFF
--- a/src/@types/Canvas.d.ts
+++ b/src/@types/Canvas.d.ts
@@ -240,6 +240,7 @@ export interface Canvas {
   /** Basically setData (if clearCanvas == true), but without modifying the history */
   importData(data: CanvasElementsData, clearCanvas?: boolean, /* custom */ silent?: boolean): void
   clear(): void
+  cloneData(newItems: CanvasElementsData, shift: Position): CanvasElementsData
 
   nodes: Map<string, CanvasNode>
   edges: Map<string, CanvasEdge>


### PR DESCRIPTION
Fixing the issue #287.

There are two ways of copy node:
1. ⌘C → ⌘V
2. Mouse drag-n-drop, while holding ⌥ key

Both of them generates the following sequence of calls:

<img width="500px" src="https://github.com/user-attachments/assets/1cf13524-201e-4c65-9ca2-8fb8612fded3"/>

But for the 2nd way of copy, there is bug #287. There is another point, when things go wrong and it seems, it is Obsidian's bug. I cannot find the right point to patch it, so I've patched the most early call: `cloneData`.