### PR TITLE
fix: avoid data loss caused by portals when IDs contain dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,9 @@ Embed other canvases inside your current canvas and create edges (arrows) to the
 
 <img src="https://raw.githubusercontent.com/Developer-Mike/obsidian-advanced-canvas/main/assets/docs/sample-portal-usage.png" alt="Portal example"/>
 
+### Notes
+*   **ID compatibility:** Portals use `-` to prefix nested element IDs (`portalId-originalId`). If Advanced Canvas detects `-` in any node/edge ID on a canvas (e.g., programmatically generated UUIDs), it disables Portals for that canvas and shows a notice to prevent data loss. To re-enable, use IDs without `-` and reload the canvas.
+
 ### Usage
 *   Embed a canvas file, then click the door icon in the popup menu to open it as a portal.
 

--- a/assets/formats/advanced-json-canvas/README.md
+++ b/assets/formats/advanced-json-canvas/README.md
@@ -2,6 +2,8 @@
 
 The Advanced JSON Canvas format is a structured way to represent a canvas with nodes and edges. It is designed to be extensible and flexible, allowing for various types of nodes and connections between them. It's completely compatible with the standard JSON Canvas format, but adds more features and flexibility.
 
+Note (Advanced Canvas): The Portals feature reserves `-` in element IDs (e.g., `portalId-originalId`). Avoid `-` in node/edge IDs for best compatibility (portals may be disabled on canvases that contain `-`).
+
 Version name consists of two parts: the JSON Canvas version and the Advanced JSON Canvas version. It's in the following order: `<json-canvas-version>-<advanced-json-canvas-version>`. For example, `1.0-1.0` means JSON Canvas version 1.0 and Advanced JSON Canvas version 1.0.
 
 Check out the [specification](spec/1.0-1.0.md) for more details on how to use this format.

--- a/assets/formats/advanced-json-canvas/spec/1.0-1.0.d.ts
+++ b/assets/formats/advanced-json-canvas/spec/1.0-1.0.d.ts
@@ -14,6 +14,10 @@ export interface CanvasMetadata {
 
 export type CanvasNodeType = 'text' | 'group' | 'file' | 'link'
 export interface CanvasNodeData {
+  /**
+   * Unique ID for the node.
+   * Note (Advanced Canvas): `-` is reserved for portal-nested element IDs.
+   */
   id: string
   type: CanvasNodeType
 
@@ -65,13 +69,25 @@ export interface CanvasGroupNodeData extends CanvasNodeData {
 type Side = 'top' | 'right' | 'bottom' | 'left'
 type EndType = 'none' | 'arrow'
 export interface CanvasEdgeData {
+  /**
+   * Unique ID for the edge.
+   * Note (Advanced Canvas): `-` is reserved for portal-nested element IDs.
+   */
   id: string
 
+  /**
+   * ID of the node where the connection starts.
+   * Note (Advanced Canvas): `-` is reserved for portal-nested element IDs.
+   */
   fromNode: string
   fromSide: Side
   fromFloating?: boolean // AdvancedJsonCanvas
   fromEnd?: EndType
   
+  /**
+   * ID of the node where the connection ends.
+   * Note (Advanced Canvas): `-` is reserved for portal-nested element IDs.
+   */
   toNode: string
   toSide: Side
   toFloating?: boolean // AdvancedJsonCanvas

--- a/assets/formats/advanced-json-canvas/spec/1.0-1.0.md
+++ b/assets/formats/advanced-json-canvas/spec/1.0-1.0.md
@@ -33,7 +33,7 @@ Nodes are placed in the array in ascending order by z-index. The first node in t
 
 All nodes include the following attributes:
 
-- `id` (required, string) is a unique ID for the node. Refrain from using `-` in the ID, as it is used to identify and manage nodes that are from portals.
+- `id` (required, string) is a unique ID for the node. Refrain from using `-` in the ID, as it is used by portals to identify and manage nested portal elements. In Advanced Canvas, portals may be disabled for canvases that contain `-` in element IDs to prevent data loss.
 - `type` (required, string) is the node type.
   - `text`
   - `file`
@@ -104,7 +104,7 @@ Group type nodes are used as a visual container for nodes within it. Along with 
 
 Edges are lines that connect one node to another.
 
-- `id` (required, string) is a unique ID for the edge. Refrain from using `-` in the ID, as it is used to identify and manage edges that are from portals.
+- `id` (required, string) is a unique ID for the edge. Refrain from using `-` in the ID, as it is used by portals to identify and manage nested portal elements. In Advanced Canvas, portals may be disabled for canvases that contain `-` in element IDs to prevent data loss.
 - `fromNode` (required, string) is the node `id` where the connection starts.
 - `fromSide` (required, string) is the side where this edge starts. Valid values:
   - `top`
@@ -167,4 +167,4 @@ Specific values for the preset colors are intentionally not defined so that appl
 ## Portal
 Portals are a special type of file node that allow you to embed another canvas within the current canvas. Portals don't need to be interactive, but they can be. Edges between portal nodes and nodes within the host canvas are supported and stored in the `interdimensionalEdges` object.
 
-Edges and nodes that got created to represent elements (nodes and edges) from a portal node are not stored in the canvas. Instead, they are stored only in the canvas file the portal points to. Temporary edges' and nodes' IDs *can* be prefixed with the portal node's ID to remain unique within the canvas and to easily identify them as temporary elements.
+Edges and nodes that got created to represent elements (nodes and edges) from a portal node are not stored in the canvas. Instead, they are stored only in the canvas file the portal points to. Temporary edges' and nodes' IDs *can* be prefixed with the portal node's ID (e.g., `portalId-originalId`) to remain unique within the canvas and to easily identify them as temporary elements.


### PR DESCRIPTION
I identified a data loss issue where nodes/edges with - in their IDs (e.g. UUIDs from programmatic creation) could be silently deleted after a drag/save cycle. 

This PR introduces a fail-closed safety mechanism: when a canvas contains - in element IDs, Portals are disabled for that canvas and a notice is shown, preventing the Portals save pipeline from filtering out legitimate elements.

Minimal-intrusion mitigation, scoped to the affected canvas only:
  - Keep the existing portal ID encoding (-) unchanged for now (avoids broad format/compatibility changes).
  - Add a per-canvas “portal disabled” state keyed by canvas.view.file.path.
  - Detect incompatible IDs on:
      - advanced-canvas:data-loaded:before (load) → disable before opening portals
      - advanced-canvas:data-requested (save) → disable before filtering
  - When disabled, Portals does no portal processing (per request), and we show a one-time notice per disable session. Re-enable happens automatically after IDs are fixed and the canvas is reloaded.

How to Verify
1. Create a canvas with nodes/edges whose IDs contain - (e.g. UUIDs).
2. Interact (drag) and trigger a save.
3. Expected: a notice appears and Portals features are disabled for that canvas; nodes/edges are not deleted.
4. Remove - from IDs and reload the canvas.
5. Expected: Portals works again on that canvas.