### PR TITLE
Context filter for focused node

### DIFF
--- a/src/canvas-extensions/focus-mode-canvas-extension.ts
+++ b/src/canvas-extensions/focus-mode-canvas-extension.ts
@@ -7,7 +7,7 @@ const CONTROL_MENU_FOCUS_TOGGLE_ID = 'focus-mode-toggle'
 const FOCUS_MODE_ENABLED = "focusModeEnabled"
 const FOCUS_HIDE_NODES_ENABLED = "focusHideNodesEnabled"
 
-const NODE_NEIGHBOR_CLASS = "ac-context-neighbor"
+const NODE_NEIGHBOR_CLASS = "ac-focus-neighbor"
 const HIDDEN_CLASS = "ac-focus-hidden"
 
 export default class FocusModeCanvasExtension extends CanvasExtension {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -111,8 +111,6 @@ export interface AdvancedCanvasPluginSettingsValues {
 
   edgeSelectionEnabled: boolean
   selectEdgeByDirection: boolean
-
-  contextFilterEnabled: boolean
 }
 
 export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
@@ -211,8 +209,6 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   edgeSelectionEnabled: false,
   selectEdgeByDirection: false,
-
-  contextFilterEnabled: false,
 }
 
 export const SETTINGS = {
@@ -637,12 +633,6 @@ export const SETTINGS = {
         type: 'boolean'
       }
     }
-  },
-  contextFilterEnabled: {
-    label: 'Context Filter',
-    description: 'Show only nodes connected to the selected node (one level deep).',
-    infoSection: 'context-filter',
-    children: { }
   },
   focusModeFeatureEnabled: {
     label: 'Focus mode',

--- a/src/styles/focus-mode.scss
+++ b/src/styles/focus-mode.scss
@@ -1,5 +1,5 @@
-.canvas-wrapper[data-focus-mode-enabled="true"] .canvas:has(.canvas-node.is-focused, .canvas-node.ac-context-neighbor) {
-  .canvas-node:not(.is-focused):not(.ac-context-neighbor) {
+.canvas-wrapper[data-focus-mode-enabled="true"] .canvas:has(.canvas-node.is-focused, .canvas-node.ac-focus-neighbor) {
+  .canvas-node:not(.is-focused):not(.ac-focus-neighbor) {
     filter: blur(5px);
   }
 


### PR DESCRIPTION
Hi, for big size canvases it helps a lot. May be you will love it too :)

Feature add:
- Optional switch and toggle button (near the focus mode on a toolbox)
- Hide everything except focused node and it's neighbor
- Integrates with Focus mode - blur everything except context filtered nodes and edges.

Demo:
![obsidian_canvas_context_focus](https://github.com/user-attachments/assets/ba0ba104-eead-421c-b491-01f0c7c844c8)
