### PR TITLE
Fix custom colors sample in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Add custom colors to the color picker. You can add them using the following CSS 
 ```css
 body {
     /* Where X is the index of the color in the palette (1-6 are used by Obsidian) */
-    --canvas-color-X: 0, 255, 0; /* RGB values */
+    --canvas-color-X: rgb(0, 255, 0); /* RGB values */
 }
 ```
 


### PR DESCRIPTION
The code from the readme didn't work for me, but wrapping the numbers in rgb() worked fine.

Without rgb() all the new colors were white

My system: Arch Linux, Advanced Canvas 6.4.0, Obsidian 1.13.4