### PR TITLE
fix: update --canvas-color usage for Obsidian 1.13+

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Add custom colors to the color picker. You can add them using the following CSS 
 ```css
 body {
     /* Where X is the index of the color in the palette (1-6 are used by Obsidian) */
-    --canvas-color-X: 0, 255, 0; /* RGB values */
+    --canvas-color-X: rgb(0, 255, 0); /* RGB values */
 }
 ```
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "advanced-canvas",
   "name": "Advanced Canvas",
   "version": "6.5.0",
-  "minAppVersion": "1.7.2",
+  "minAppVersion": "1.13.0",
   "description": "Supercharge your canvas experience! Create presentations, flowcharts and more!",
   "author": "Developer-Mike",
   "authorUrl": "https://github.com/Developer-Mike",

--- a/src/styles/collapsible-groups.scss
+++ b/src/styles/collapsible-groups.scss
@@ -10,7 +10,7 @@
   
   border-radius: var(--radius-s);
   color: var(--text-muted);
-  background-color: rgba(var(--canvas-color), 0.1);
+  background-color: rgb(from var(--canvas-color) r g b / 0.1);
 
   font-size: 1.5em;
   line-height: 1;

--- a/src/styles/edge-styles.scss
+++ b/src/styles/edge-styles.scss
@@ -19,16 +19,16 @@
   [data-arrow='triangle-outline'], [data-arrow='diamond-outline'], [data-arrow='circle-outline'] {
     polygon {
       fill: var(--canvas-background);
-      
-      stroke: rgb(var(--canvas-color));
+
+      stroke: var(--canvas-color);
       stroke-width: calc(3px * var(--zoom-multiplier));
     }
   }
 
   [data-arrow='thin-triangle'] polygon {
     fill: transparent;
-    
-    stroke: rgb(var(--canvas-color));
+
+    stroke: var(--canvas-color);
     stroke-width: calc(4px * var(--zoom-multiplier));
   }
 }

--- a/src/styles/embeds.scss
+++ b/src/styles/embeds.scss
@@ -5,16 +5,16 @@
   overflow: hidden;
   background-color: var(--background-primary);
 
-  border: 1px solid rgb(var(--canvas-color));
+  border: 1px solid var(--canvas-color);
   border-radius: var(--radius-m);
 
   box-shadow: var(--shadow-stationary);
 
   &.is-themed {
-    background-color: rgba(var(--canvas-color), 0.07);
+    background-color: rgb(from var(--canvas-color) r g b / 0.07);
 
-    border-color: rgba(var(--canvas-color), 0.7);
-    box-shadow: inset 0 0 0 1px rgba(var(--canvas-color), 0.7), var(--shadow-stationary);
+    border-color: rgb(from var(--canvas-color) r g b / 0.7);
+    box-shadow: inset 0 0 0 1px rgb(from var(--canvas-color) r g b / 0.7), var(--shadow-stationary);
   }
 
   & > .markdown-content {

--- a/src/styles/node-styles.scss
+++ b/src/styles/node-styles.scss
@@ -1,5 +1,5 @@
 .reactive-node {
-  --border-color: rgb(var(--canvas-color));
+  --border-color: var(--canvas-color);
   --border-width: 3px;
   --box-shadow: none;
 
@@ -12,18 +12,19 @@
 
   /* Themed */
   &.is-themed {
-    --border-color: rgba(var(--canvas-color), 0.7);
+    --border-color: rgb(from var(--canvas-color) r g b / 0.7);
   }
 
   &.is-themed {
     &.is-focused, &.is-selected {
-      --border-color: rgb(var(--canvas-color));
+      --border-color: var(--canvas-color);
       --box-shadow: var(--shadow-border-themed);
     }
   }
 }
 
 .canvas-node {
+
   //#region Text Alignment
   &[data-text-align='center'] {
     .markdown-preview-view {
@@ -43,6 +44,7 @@
   &[data-text-align='right'] {
     text-align: right;
   }
+
   //#endregion
 
   //#region Shape
@@ -232,7 +234,7 @@
     /* Add theme fill if not editing */
     &.is-themed:not(:has(.embed-iframe)) {
       .canvas-node-container, &::after, &::before {
-        box-shadow: inset 0 0 0 1000px rgba(var(--canvas-color), 0.07) !important;
+        box-shadow: inset 0 0 0 1000px rgb(from var(--canvas-color) r g b / 0.07) !important;
       }
     }
 
@@ -246,6 +248,7 @@
       z-index: -1;
     }
   }
+
   //#endregion
 
   //#region Borders
@@ -275,6 +278,7 @@
       box-shadow: none;
     }
   }
+
   //#endregion
 
   //#region Combinations


### PR DESCRIPTION
Hello,

I've noticed that shapes and nodes are broken in Obsidian 1.13+. This seems to be caused by changes in how `--canvas-color` (and `--canvas-color-1` ... `--canvas-color-6`) works. The `--canvas-color*` variables now provides valid css color values (e.g. `#ff0000`) instead of a bare RGB triplet (`255,0,0`). *tho this isn't mentioned in the 1.13 changelog*

### changes
1. set min version to 1.13.0
2. change bare RGB triplets
```css
/* Before (broken on 1.13+) */
--canvas-color-1: rgb(var(--canvas-color)); /* rgb(rgb(255, 0, 0)) */
/* After */
--canvas-color-1: var(--canvas-color); /* rgb(255, 0, 0) */
```
3. change wrapped var(--canvas-color) in rgba()
```css
/* Before (produces invalid rgba(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: rgb(from var(--canvas-color) r g b / 0.1);
```

| before | after |
| - | - |
| <img width="647" height="528" alt="image" src="https://github.com/user-attachments/assets/81a56c0c-84b0-46eb-afbe-759ea9801f51" /> |  <img width="758" height="496" alt="image" src="https://github.com/user-attachments/assets/be327ad4-cc7e-4c71-87a9-e027d386eec2" />|

closes https://github.com/Developer-Mike/obsidian-advanced-canvas/issues/409
