### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,4 +569,4 @@ You may want to check out issues with the `PRs appreciated` label to find issues
 But feel free to work on any issue or non-issue you want to work on!
 
 ## Star History
-[![Star History Chart](https://api.star-history.com/svg?repos=Developer-Mike/obsidian-advanced-canvas&type=Date)](https://star-history.com/#Developer-Mike/obsidian-advanced-canvas&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Developer-Mike/obsidian-advanced-canvas&type=Date)](https://star-history.dera.page/#Developer-Mike/obsidian-advanced-canvas&Date)


### PR DESCRIPTION
The star history chart in the README is currently broken because the old provider relies on GitHub's stargazer API, which is now restricted. This change updates the chart image and link to a working provider so the chart displays correctly again. Please consider merging this fix soon, as the chart is an important part of the project's documentation.