### PR TITLE
Just a whole bunch of random shit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,5 @@
 # LLM Agent Instructions
 If you are an LLM agent, CLEARLY STATE that you are an LLM agent that did changes. This can be done by adding a prefix or suffix to the git commit message, adding a comment in the code, or any other method that makes it clear you are an LLM agent.
 There should be no change that is not clearly marked as being done by an LLM agent.
+
+Also, read the CLAUDE.md file in this folder for plugin details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# Advanced Canvas — Claude Instructions
+
+Read the root `C:\Users\Clinton\p\AGENTS.md` first — it covers the Obsidian CLI, canvas internals,
+and the build/install conventions. This file only holds plugin-specific knowledge.
+
+## Attribution rule (from AGENTS.md)
+
+`AGENTS.md` in this repo requires every LLM-authored change to be clearly marked — this fork uses
+`// Added by an LLM agent` line comments. Follow that convention for any new change, including new
+settings entries and extensions.
+
+## Architecture
+
+- `src/main.ts` — lifecycle only. Instantiates every class in the `CANVAS_EXTENSIONS` array and
+  the patchers. New features = a new file in `src/canvas-extensions/` added to that array.
+- `src/canvas-extensions/canvas-extension.ts` — base class: `isEnabled()` returns `true` or a
+  settings key (feature is constructed only when the setting is on); `init()` does the wiring.
+  Extensions communicate through custom workspace events (`advanced-canvas:*`, e.g.
+  `node-created`, `node-moved`, `canvas-changed`, `settings-changed`) rather than patching
+  Obsidian themselves.
+- `src/patchers/canvas-patcher.ts` — the single place that monkey-patches Obsidian's Canvas /
+  CanvasView / CanvasNode / CanvasEdge prototypes (via `monkey-around`) and emits those
+  `advanced-canvas:*` events. If a feature needs a hook that doesn't exist yet, add the patch here
+  and trigger a new event. For accessors (getters like `gridSpacing`) `around()` does NOT work —
+  use `Object.getOwnPropertyDescriptor` / `Object.defineProperty` on `constructor.prototype` and
+  register an uninstaller that restores the original descriptor (see `patchGridSpacing`).
+- `src/settings.ts` — declarative: `AdvancedCanvasPluginSettingsValues` interface +
+  `DEFAULT_SETTINGS_VALUES` + the `SETTINGS` tree that auto-generates the settings tab. A new
+  setting needs an entry in all three. Feature headings get a toggle that "requires reload";
+  settings read live (like `gridSize`) take effect immediately because the patched getter reads
+  `settings.getSetting(...)` on every call.
+- `src/@types/Canvas.d.ts` — hand-maintained typings of Obsidian's private canvas API. Extend it
+  when you touch a new internal.
+- `src/utils/canvas-helper.ts` — shared helpers. `CanvasHelper.GRID_SIZE = 20` is still the
+  hardcoded default for edge-pathfinding margins; position/size snapping code should read the
+  `gridSize` setting instead (see `better-default-settings-canvas-extension.ts` and
+  `auto-resize-node-canvas-extension.ts`).
+
+## Grid size feature (added by an LLM agent)
+
+Obsidian's snap grid is a zoom-dependent `gridSpacing` getter on the Canvas prototype
+(tiers 20/40/80/160). `patchGridSpacing` in `canvas-patcher.ts` overrides it to return multiples
+of the `gridSize` setting (General section, default 20). This one accessor controls drag/resize
+snapping, arrow-key nudging, arrange spacing, and the background grid pattern.
+
+## "Default X" style settings pattern (added by an LLM agent)
+
+The pattern behind `defaultGroupLabelSize` / `defaultGroupOpacity` / `defaultEdgeWidth` /
+`defaultArrowSize` / `defaultNodeBorder` — use it for any new "default value of a per-element
+style" setting:
+
+1. Dropdown setting in the General section of `settings.ts` with an explicit "leave Obsidian
+   alone" option (`'1'` for size multipliers, `'default'` otherwise).
+2. Add it to `DEFAULT_SIZE_SETTINGS` in `default-style-sizes-canvas-extension.ts` (with
+   `unchangedValue` if it isn't `'1'`). The extension exposes it as a `data-*` attribute on the
+   canvas wrapper, and only while it differs from the unchanged value — the CSS is keyed on the
+   attribute's *presence*, so Obsidian stays untouched by default.
+3. Add the rules in `src/styles/default-style-sizes.scss`. An element's own explicit value must
+   win: sizes do it with a `var(--x-multiplier, var(--default-x-multiplier, 1))` fallback, the
+   node border does it with `:not([data-border])` (per-node style attributes are exposed as
+   `data-*` on `node.nodeEl` by `dataset-exposers/node-exposer.ts` — but only while
+   `nodeStylingFeatureEnabled` is on, so never rely on those attributes existing for behavior
+   that must also work with node styling disabled).
+
+## Canvas filter & portals/groups (added by an LLM agent)
+
+`canvas-filter-canvas-extension.ts` never builds its graph from `canvas.getData()` — the portals
+extension strips all portal elements from `getData()` output (`onGetData`, hooked via
+`advanced-canvas:data-requested`), so any filter built on it is portal-blind. The filters instead
+read the live `canvas.nodes` / `canvas.edges` maps (per-element `getData()` is not hooked). Live
+portal elements look like ordinary nodes/edges with `acportal||`-prefixed ids;
+`PortalsCanvasExtension.getNestedIds(id)` splits those ids, `isPortalElement(id)` detects them.
+
+- Connection filters (`filterByConnections`, BFS from the selection): reaching an open portal
+  node (a `file` node with `portal: true`) reveals its entire nested content; reaching a group
+  node reveals every bbox-contained node (`bboxContains`, so nested groups are covered too). Both
+  expansions run inside the BFS loop and traversal continues from the revealed nodes. After
+  traversal, **every** edge with both endpoints visible is shown, not just the edges the
+  traversal followed (A→B, A→C, B→C + filter from A shows B→C as well).
+- `filter-immediately-connected-nodes` is the one-hop variant: `ConnectionFilter.immediate` in
+  `CONNECTION_FILTERS` breaks after the first BFS iteration (portal/group expansion of first-hop
+  nodes still runs).
+- The color filter is portal-aware the same way: matching portal nodes expand to their full
+  content; portal-internal nodes are excluded from direct color matching.
+- Shared helpers on the extension class: `getPortalNestedNodes(nodes, portalId)` /
+  `getPortalInternalEdges(edges, portalId)`.
+- `filterByTag` still reads `canvas.getData().nodes` for its candidates (portal-blind) — not yet
+  aligned with the others.
+
+## Hidden ".md" files in the canvas file search (added by an LLM agent)
+
+Files named exactly `.md` are dotfiles — Obsidian's vault layer never indexes them
+(`vault.getFiles()` / `getAbstractFileByPath('.md')` return nothing), but
+`vault.adapter.list()` still sees them. `src/patchers/dot-md-file-search-patcher.ts`
+patches `Modal.prototype.open`, duck-types the canvas "Add note from vault" suggest
+modal (the only suggest modal carrying a `.canvas` with `shouldShowMarkdown === true`),
+and wraps the instance's `getSuggestions` / `renderSuggestion` / `onChooseSuggestion`
+to inject `.md` files discovered by an adapter walk (skipping dot-folders). Injected
+items are marked with `acDotMdPath` and carry a fake TFile duck-type
+(`path/name/basename/extension/stat/getShortName`) because no real TFile exists.
+Gated by the `dotMdFileSearchEnabled` feature heading (default on, requires reload).
+
+## Build & install
+
+- `npm run build` — esbuild (bundle + sass) straight into `dist/`; `manifest.json` is copied by
+  `esbuild-plugin-copy`. **The build does not type-check** — run `npx tsc -noEmit -skipLibCheck`
+  separately.
+- `npm run dev` — watch mode, same output.
+- `dist/` is a junction **into** the main vault
+  (`dist -> C:\Users\Clinton\o\g\main\.obsidian\plugins\advanced-canvas`), i.e. the reversed-link
+  style from the root CLAUDE.md — rebuilds are live in the vault with no copy step. Don't
+  "normalize" the link direction. The **Company Documentation** vault also points its plugin
+  folder at the same `dist/` (normal direction:
+  `.obsidian\plugins\advanced-canvas -> C:\Users\Clinton\p\obsidian-advanced-canvas\dist`), so
+  rebuilds are live there too — reload whichever vault you're testing
+  (`obsidian vault='Company Documentation' reload`).
+- After rebuilding, `obsidian plugin:reload` does NOT pick up junctioned code — use a full
+  `obsidian vault=main reload`.
+
+## Live testing
+
+CLI calls here take ~60s each; run them in the background and batch probes into one eval.
+Plugin object: `app.plugins.plugins['advanced-canvas']` (has `.settings.getSetting(key)` /
+`.setSetting({...})`, which fires `advanced-canvas:settings-changed` — settings that are read
+live apply immediately, no reload needed). Find a canvas with
+`app.workspace.iterateAllLeaves(l => ... l.view.canvas ...)`, but expect several canvas leaves —
+identify yours by a known node id, not by position. Open a canvas file with
+`await app.workspace.openLinkText(path, '', 'tab')` — `setViewState` can leave an `empty` view.
+If the Obsidian window is hidden, nodes don't render (empty `nodeEl`s, no computed styles) —
+verify CSS targeting headlessly with `nodeEl.matches('<full selector>')` plus a
+`document.styleSheets` rule search instead.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This plugin enhances the Obsidian canvas with a wide array of features:
     *   [Improved Image Export](#image-export): Export to PNG/SVG with transparency and other options.
 *   **Node Customization:**
     *   [Node Templates](#node-templates): Save and reuse node styles as templates.
-    *   [Node Styles](#node-styles): Includes various [Flowchart Shapes](#node-shapes), [Border Styles](#border-styles), and Text Alignment.
+    *   [Node Styles](#node-styles): Includes various [Flowchart Shapes](#node-shapes), [Border Styles](#border-styles), [Group Label Size](#group-label-size), [Group Opacity](#group-opacity), and Text Alignment.
     *   [Auto Node Resizing](#auto-node-resizing): Nodes adapt to their content size automatically.
     *   [Variable Breakpoints](#variable-breakpoints): Control content rendering based on zoom level.
     *   [Alternative Text Rendering](#alternative-text-rendering): Fix rendering inconsistencies between nodes in edit mode and reading mode.
@@ -40,6 +40,7 @@ This plugin enhances the Obsidian canvas with a wide array of features:
     *   [Edge Styles](#edge-styles): Includes [Path Styles](#path-styles) (dotted, dashed), [Arrow Styles](#arrow-styles), and [Pathfinding Methods](#pathfinding-methods).
     *   [Floating Edges](#floating-edges-automatic-edge-side): Edges automatically adjust their connection side.
     *   [Flip Edge](#flip-edge): Quickly reverse edge direction.
+    *   [Markdown Edge Labels](#markdown-edge-labels): Render edge labels as markdown - links, embeds, formatting and code blocks.
 *   **Interaction & Workflow:**
     *   [Canvas Commands](#canvas-commands): A suite of commands for efficient canvas manipulation.
     *   [Native-Like File Search](#native-like-file-search): Search for text within the whole canvas using a native-like interface.
@@ -49,6 +50,7 @@ This plugin enhances the Obsidian canvas with a wide array of features:
     *   [Edge Highlight](#edge-highlight): Highlight edges when a connected node is selected.
     *   [Edge Selection](#edge-selection): Select edges connected to the selected node(s).
     *   [Focus Mode](#focus-mode): Highlight a single node by blurring others.
+    *   [Canvas Filter](#canvas-filter): Temporarily hide everything that doesn't match a color, tag or connection filter.
     *   [Encapsulate Selection](#encapsulate-selection): Move selected nodes to a new canvas, linking back to it.
     *   Create groups independently of the nodes.
 *   **Styling & Extensibility:**
@@ -154,6 +156,7 @@ Advanced Canvas now allows you to link or embed the content of a *single node* f
 *   Customize default file node size
 *   Modify the minimum node size
 *   Disable the font scaling relative to the zoom level
+*   Connect edges to the arrow base - end an edge's line at the back of its arrow head instead of running it on towards the node, so a line that arrives at an angle meets the arrow centred instead of off to one side (triangle arrow heads only)
 
 ## Native-Like File Search
 Quickly locate text within your canvas using a familiar search experience. Advanced Canvas integrates a native-like file search specifically for canvas content.
@@ -173,6 +176,10 @@ Quickly locate text within your canvas using a familiar search experience. Advan
 
 *   `Advanced Canvas: Toggle readonly`
     *   Toggle the readonly state of the canvas
+*   `Advanced Canvas: Toggle invisible style` <sup>(added by an LLM agent)</sup>
+    *   Hide/unhide the selection — the same `Invisible` (eye-off) option the style menu offers, applied to the whole selection at once (`Border` for nodes, `Path Style` for edges)
+    *   Hides everything selected unless it is already fully hidden, in which case it is unhidden
+    *   Unhiding restores the style each element had before it was hidden (e.g. a dashed border), not the default one
 *   `Advanced Canvas: Create text node`
     *   Create a new text node
 *   `Advanced Canvas: Create file node`
@@ -274,13 +281,34 @@ Set the style of the border to dotted, dashed or invisible.
     <img src="https://raw.githubusercontent.com/Developer-Mike/obsidian-advanced-canvas/main/assets/docs/border-styles.png" alt="Border Styles Example"/>
 </details>
 
+### Group Label Size
+Set the font size of a group's label. The value is a multiplier applied on top of the default label size - the label still scales with the zoom level as usual, it just gets bigger or smaller relative to everything else.
+
+#### Usage
+*   Select a group and use the `Label Size` option in the popup menu to pick a multiplier (0.75x, 1x, 1.5x, 2x or 3x).
+
+Need a size that isn't in the list? Add your own value with a [custom style](#custom-styles) that sets `--group-label-size-multiplier` on the node.
+
+Labels that are too long for their group wrap onto multiple lines instead of being cut off. This is enabled by default and can be turned off with the `Wrap group labels` setting under `General`.
+
+### Group Opacity
+Set how strongly a group's fill is tinted with its colour. Obsidian's own default is a 7% tint; at 100% the group becomes a solid block of colour. Only the fill changes - the border, the label and the nodes inside the group stay fully visible.
+
+#### Usage
+*   Select a group and use the `Opacity` option in the popup menu to pick a value (default 7%, 25%, 50%, 75% or solid 100%).
+*   Set the `Default group opacity` setting under `General` to apply an opacity to every group that doesn't have one of its own.
+
+Need a value that isn't in the list? Add your own with a [custom style](#custom-styles) that sets `--group-opacity` on the node (`1` = solid).
+
 *(Note: Text Alignment options (Left, Center, Right) are also available for nodes.)*
 
 ## Edge Styles
 You can customize the default edge styles using the settings.
 
 ### Path Styles
-Set the style of the edge paths to dotted, short-dashed or long-dashed.
+Set the style of the edge paths to dotted, short-dashed, long-dashed or invisible.
+
+The `Invisible` path style hides the line and its arrow heads while keeping the edge itself intact — it stays selectable where it runs, and its label (if it has one) stays visible. Hovering or selecting an invisible edge fades it back in faintly so you can still find it; exported images keep it fully hidden.
 
 <details>
     <summary>Edge Path Styles Example</summary>
@@ -294,6 +322,12 @@ Set the style of the arrows to triangle outline, halved triangle, thin triangle,
     <summary>Arrow Styles Example</summary>
     <img src="https://raw.githubusercontent.com/Developer-Mike/obsidian-advanced-canvas/main/assets/docs/edge-arrow-styles.png" alt="Edge Arrow Styles Example"/>
 </details>
+
+### Edge Width
+Set the thickness of the edge path to thin (0.5x), default (1x), thick (2x) or extra thick (3x).
+
+### Arrow Size
+Set the size of the edge's arrows to small (0.5x), default (1x), large (1.5x) or extra large (2x).
 
 ### Pathfinding Methods
 Set the pathfinding method of the edges (arrows) to default, straight, squared or A*.
@@ -485,6 +519,24 @@ Resize nodes automatically when their text content changes. Toggle this feature 
     <img src="https://raw.githubusercontent.com/Developer-Mike/obsidian-advanced-canvas/main/assets/docs/auto-node-resizing.gif" alt="Auto Node Resizing Example"/>
 </details>
 
+## Markdown Edge Labels
+<!-- Added by an LLM agent -->
+Render edge labels as markdown instead of plain text. Anything Obsidian can render in a note works in a label - bold/italic text, internal and external links, embeds (`![[Note#^block]]`), lists, and code blocks (including ones provided by other plugins).
+
+### Render mode
+The "Render mode" setting controls how much of that is actually rendered:
+
+- **Embeds only** (default) - a label is only rendered when it is *nothing but* note embeds. That means either one or more bare `![[Note#^block]]` embeds (one per line), or a single ` ```sync ` block whose body is bare embeds. Every other label - prose, formatting, a bare `[[link]]`, an embed with text around it - is left exactly as core Obsidian renders it, as plain text. Use this when you only want labels to pull their content out of a note and want the rest to stay predictable.
+- **Full markdown** - render every label as markdown.
+
+Switching modes re-renders open canvases immediately; no reload needed.
+
+Clicking a label still selects the edge, and clicking it again opens it for editing, where the **raw markdown source** is shown so it stays editable as plain text. Clicking a link, embed or other interactive element inside a rendered label activates that element instead of entering edit mode.
+
+Labels containing an embed, table or image get a fixed width (they have no intrinsic width and would otherwise collapse to a few pixels) and a capped height - both are configurable in the settings via "Max label width" and "Max label height". Taller content scrolls inside the label.
+
+To style rendered labels yourself, target the `.canvas-path-label.ac-markdown-label` CSS class in a custom CSS snippet (`.ac-markdown-label-block` is additionally set on labels with embedded content).
+
 ## Edge Highlight
 Highlight edges when a connected node is selected. This feature helps to visually identify relationships between nodes.
 
@@ -498,6 +550,35 @@ If "[Edge Highlight](#edge-highlight)" is enabled, edges connected to the focuse
 <details>
     <summary>Focus Mode Example</summary>
     <img src="https://raw.githubusercontent.com/Developer-Mike/obsidian-advanced-canvas/main/assets/docs/focus-mode.png" alt="Focus Mode Example"/>
+</details>
+
+## Canvas Filter
+<!-- Added by an LLM agent -->
+Temporarily hide the nodes and edges that don't match a filter, so you can concentrate on one part of a large canvas. The filter is purely visual - nothing is written to the canvas file, and reopening the canvas (or `Advanced Canvas: Reset filter`) brings everything back.
+
+Group nodes stay visible as long as they fully contain at least one of the remaining nodes.
+
+<details>
+    <summary>View available commands</summary>
+
+*   `Advanced Canvas: Reset filter`
+    *   Show all nodes and edges again
+*   `Advanced Canvas: Filter by color of selection`
+    *   Show only the nodes that have one of the colors of the current selection
+    *   If one of the selected elements has no color, colorless nodes stay visible as well
+*   `Advanced Canvas: Filter by tag`
+    *   Pick a tag and show only the nodes carrying it - file nodes are matched via their metadata (including frontmatter tags), text nodes via their content
+    *   Nested tags are included, e.g. filtering by `#project` also shows nodes tagged `#project/canvas`
+*   `Advanced Canvas: Filter to selection and connected nodes`
+    *   Show the selection plus everything reachable from it, following edges in both directions
+*   `Advanced Canvas: Filter to selection and outgoing nodes`
+    *   Same, but only follows edges pointing away from the selection
+*   `Advanced Canvas: Filter to selection and incoming nodes`
+    *   Same, but only follows edges pointing towards the selection
+*   `Advanced Canvas: Hide selection`
+    *   Hide the currently selected nodes and edges
+*   `Advanced Canvas: Hide selection and its edges`
+    *   Hide the currently selected nodes together with all edges connected to them
 </details>
 
 ## Better Readonly

--- a/assets/formats/advanced-json-canvas/spec/1.0-1.0.d.ts
+++ b/assets/formats/advanced-json-canvas/spec/1.0-1.0.d.ts
@@ -24,6 +24,8 @@ export interface CanvasNodeData {
   dynamicHeight?: boolean // AdvancedJsonCanvas
   ratio?: number
   zIndex?: number // AdvancedJsonCanvas
+  rotation?: number // AdvancedJsonCanvas - Added by an LLM agent - Degrees clockwise, normalized to [0, 360); removed when 0
+  contentRotation?: 0 | 90 | 180 | 270 // AdvancedJsonCanvas - Added by an LLM agent - Rotates only the node's inner content; removed when 0
 
   color?: CanvasColor
 

--- a/src/@types/Canvas.d.ts
+++ b/src/@types/Canvas.d.ts
@@ -242,6 +242,7 @@ export interface Canvas {
   view: CanvasView
   config: CanvasConfig
   options: CanvasOptions
+  readonly gridSpacing: number // Added by an LLM agent - native zoom-dependent getter, patched by Advanced Canvas
 
   metadata: CanvasMetadata
 
@@ -340,6 +341,10 @@ export interface Canvas {
   removeEdge(edge: CanvasEdge): void
 
   getContainingNodes(bbox: BBox): CanvasNode[]
+  // Added by an LLM agent
+  getIntersectingNodes(bbox: BBox): CanvasNode[]
+  // Added by an LLM agent
+  getIntersectingEdges(bbox: BBox): CanvasEdge[]
   getViewportNodes(): CanvasNode[]
 
   history: CanvasHistory

--- a/src/@types/Canvas.d.ts
+++ b/src/@types/Canvas.d.ts
@@ -157,17 +157,38 @@ export interface CanvasEdgeEnd {
   end: EndType
 }
 
+/* Extended by an LLM agent: the methods below already existed on the core class, they just weren't typed */
+export interface CanvasEdgeLabelElement {
+  edge: CanvasEdge
+  initialTextState: string
+  isEditing: boolean
+  textareaEl: HTMLElement
+  wrapperEl: HTMLElement
+
+  render(): void
+  /** Replaces the label's text content */
+  setText(text: string): void
+  /** Enters edit mode (makes `textareaEl` contenteditable) */
+  focus(position?: Position): void
+  /** Leaves edit mode - destroys the label if it ended up empty */
+  blur(): void
+  /** Removes the label from the canvas and unsets `edge.labelElement` */
+  destroy(skipSave?: boolean): void
+}
+
 export interface CanvasEdge extends CanvasElement {
   label: string
 
   from: CanvasEdgeEnd
-  fromLineEnd: {
+  /** Unset while the `from` end has no arrow head */
+  fromLineEnd?: {
     el: HTMLElement
     type: 'arrow'
   }
 
   to: CanvasEdgeEnd
-  toLineEnd: {
+  /** Unset while the `to` end has no arrow head */
+  toLineEnd?: {
     el: HTMLElement
     type: 'arrow'
   }
@@ -181,19 +202,11 @@ export interface CanvasEdge extends CanvasElement {
   }
 
   path: {
-    interaction: HTMLElement
-    display: HTMLElement
+    interaction: SVGPathElement
+    display: SVGPathElement
   }
 
-  labelElement: {
-    edge: CanvasEdge
-    initialTextState: string
-    isEditing: boolean
-    textareaEl: HTMLElement
-    wrapperEl: HTMLElement
-
-    render(): void
-  }
+  labelElement: CanvasEdgeLabelElement | null
 
   lineGroupEl: HTMLElement
   lineEndGroupEl: HTMLElement

--- a/src/@types/CustomWorkspaceEvents.d.ts
+++ b/src/@types/CustomWorkspaceEvents.d.ts
@@ -48,6 +48,8 @@ export interface CustomWorkspaceEvents {
   'advanced-canvas:node-changed': (canvas: Canvas, node: CanvasNode) => void
   /** Fired when any edge gets changed */
   'advanced-canvas:edge-changed': (canvas: Canvas, edge: CanvasEdge) => void
+  /** Fired after an edge recalculated its default path (`bezier` and the `d` attributes are already set) */
+  'advanced-canvas:edge-path-updated': (canvas: Canvas, edge: CanvasEdge) => void
   /** Fired when any node gets rendered */
   'advanced-canvas:node-rendered': (canvas: Canvas, node: CanvasNode) => void
   /** Fired when the text content of a node gets changed (While typing) */

--- a/src/@types/CustomWorkspaceEvents.d.ts
+++ b/src/@types/CustomWorkspaceEvents.d.ts
@@ -76,6 +76,10 @@ export interface CustomWorkspaceEvents {
   'advanced-canvas:edge-center-requested': (canvas: Canvas, edge: CanvasEdge, position: Position) => void
   /** Fired when the nodes inside a bounding box get requested */
   'advanced-canvas:containing-nodes-requested': (canvas: Canvas, bbox: BBox, nodes: CanvasNode[]) => void
+  /** Added by an LLM agent: Fired when the nodes intersecting a bounding box get requested (e.g. by Obsidian's viewport virtualization) */
+  'advanced-canvas:intersecting-nodes-requested': (canvas: Canvas, bbox: BBox, nodes: CanvasNode[]) => void
+  /** Added by an LLM agent: Fired when the edges intersecting a bounding box get requested (e.g. by Obsidian's viewport virtualization) */
+  'advanced-canvas:intersecting-edges-requested': (canvas: Canvas, bbox: BBox, edges: CanvasEdge[]) => void
   /** Fired when the selection of the canvas changes */
   'advanced-canvas:selection-changed': (canvas: Canvas, oldSelection: Set<CanvasElement>, updateSelection: (update: () => void) => void) => void
   /** Fired before the canvas gets zoomed to a bounding box (e.g. zoom to selection, zoom to fit all) */

--- a/src/@types/Obsidian.d.ts
+++ b/src/@types/Obsidian.d.ts
@@ -105,6 +105,8 @@ declare module "obsidian" {
     linkResolver: () => void
     resolveLinks: (filepath: string) => void
     getBacklinksForFile: (file: obsidian.TFile) => { data: Map<string, ExtendedLinkCache[]> }
+    /** Added by an LLM agent: all tags of the vault, mapped to how often they're used */
+    getTags: () => { [tag: string]: number }
   }
 }
 

--- a/src/canvas-extensions/advanced-styles/style-config.ts
+++ b/src/canvas-extensions/advanced-styles/style-config.ts
@@ -161,6 +161,11 @@ export const BUILTIN_NODE_STYLE_ATTRIBUTES = [
         label: 'Default',
         value: null
       },
+	  {
+        icon: 'opacity-0',
+        label: '0%',
+        value: '0'
+      },
       {
         icon: 'opacity-25',
         label: '25%',
@@ -300,24 +305,24 @@ export const BUILTIN_EDGE_STYLE_ATTRIBUTES = [
     label: 'Edge Width',
     options: [
       {
-        icon: 'edge-width-thin',
-        label: 'Thin (0.5x)',
-        value: '0.5'
-      },
-      {
         icon: 'edge-width-default',
         label: 'Default (1x)',
         value: null
       },
       {
-        icon: 'edge-width-thick',
-        label: 'Thick (2x)',
+        icon: 'edge-width-thin',
+        label: 'Thin (2x)',
         value: '2'
       },
       {
+        icon: 'edge-width-thick',
+        label: 'Thick (4)',
+        value: '4'
+      },
+      {
         icon: 'edge-width-extra-thick',
-        label: 'Extra Thick (3x)',
-        value: '3'
+        label: 'Extra Thick (8x)',
+        value: '8'
       }
     ]
   },
@@ -326,24 +331,24 @@ export const BUILTIN_EDGE_STYLE_ATTRIBUTES = [
     label: 'Arrow Size',
     options: [
       {
-        icon: 'arrow-size-small',
-        label: 'Small (0.5x)',
-        value: '0.5'
-      },
-      {
         icon: 'arrow-size-default',
         label: 'Default (1x)',
         value: null
       },
       {
+        icon: 'arrow-size-small',
+        label: 'Small (2x)',
+        value: '2'
+      },
+      {
         icon: 'arrow-size-large',
-        label: 'Large (1.5x)',
-        value: '1.5'
+        label: 'Large (3x)',
+        value: '3'
       },
       {
         icon: 'arrow-size-extra-large',
-        label: 'Extra Large (2x)',
-        value: '2'
+        label: 'Extra Large (4x)',
+        value: '4'
       }
     ]
   },

--- a/src/canvas-extensions/advanced-styles/style-config.ts
+++ b/src/canvas-extensions/advanced-styles/style-config.ts
@@ -118,6 +118,72 @@ export const BUILTIN_NODE_STYLE_ATTRIBUTES = [
     ]
   },
   {
+    // Added by an LLM agent
+    key: 'groupLabelSize',
+    label: 'Label Size',
+    nodeTypes: ['group'],
+    options: [
+      {
+        icon: 'label-size-small',
+        label: 'Small (0.75x)',
+        value: '0.75'
+      },
+      {
+        icon: 'label-size-default',
+        label: 'Default (1x)',
+        value: null
+      },
+      {
+        icon: 'label-size-large',
+        label: 'Large (1.5x)',
+        value: '1.5'
+      },
+      {
+        icon: 'label-size-huge',
+        label: 'Huge (2x)',
+        value: '2'
+      },
+      {
+        icon: 'label-size-huge',
+        label: 'Giant (3x)',
+        value: '3'
+      }
+    ]
+  },
+  {
+    // Added by an LLM agent
+    key: 'groupOpacity',
+    label: 'Opacity',
+    nodeTypes: ['group'],
+    options: [
+      {
+        icon: 'opacity-default',
+        label: 'Default',
+        value: null
+      },
+      {
+        icon: 'opacity-25',
+        label: '25%',
+        value: '0.25'
+      },
+      {
+        icon: 'opacity-50',
+        label: '50%',
+        value: '0.5'
+      },
+      {
+        icon: 'opacity-75',
+        label: '75%',
+        value: '0.75'
+      },
+      {
+        icon: 'opacity-100',
+        label: 'Solid (100%)',
+        value: '1'
+      }
+    ]
+  },
+  {
     key: 'border',
     label: 'Border',
     options: [
@@ -169,6 +235,12 @@ export const BUILTIN_EDGE_STYLE_ATTRIBUTES = [
         icon: 'path-long-dashed',
         label: 'Long Dashed',
         value: 'long-dashed'
+      },
+      {
+        // Added by an LLM agent
+        icon: 'eye-off',
+        label: 'Invisible',
+        value: 'invisible'
       }
     ]
   },
@@ -220,6 +292,58 @@ export const BUILTIN_EDGE_STYLE_ATTRIBUTES = [
         icon: 'tally-1',
         label: 'Blunt',
         value: 'blunt'
+      }
+    ]
+  },
+  {
+    key: 'edgeWidth',
+    label: 'Edge Width',
+    options: [
+      {
+        icon: 'edge-width-thin',
+        label: 'Thin (0.5x)',
+        value: '0.5'
+      },
+      {
+        icon: 'edge-width-default',
+        label: 'Default (1x)',
+        value: null
+      },
+      {
+        icon: 'edge-width-thick',
+        label: 'Thick (2x)',
+        value: '2'
+      },
+      {
+        icon: 'edge-width-extra-thick',
+        label: 'Extra Thick (3x)',
+        value: '3'
+      }
+    ]
+  },
+  {
+    key: 'arrowSize',
+    label: 'Arrow Size',
+    options: [
+      {
+        icon: 'arrow-size-small',
+        label: 'Small (0.5x)',
+        value: '0.5'
+      },
+      {
+        icon: 'arrow-size-default',
+        label: 'Default (1x)',
+        value: null
+      },
+      {
+        icon: 'arrow-size-large',
+        label: 'Large (1.5x)',
+        value: '1.5'
+      },
+      {
+        icon: 'arrow-size-extra-large',
+        label: 'Extra Large (2x)',
+        value: '2'
       }
     ]
   },

--- a/src/canvas-extensions/auto-resize-node-canvas-extension.ts
+++ b/src/canvas-extensions/auto-resize-node-canvas-extension.ts
@@ -131,8 +131,10 @@ export default class AutoResizeNodeCanvasExtension  extends CanvasExtension {
 
     height = Math.max(height, node.canvas.config.minContainerDimension)
 
-    if (this.plugin.settings.getSetting('autoResizeNodeSnapToGrid'))
-      height = Math.ceil(height / CanvasHelper.GRID_SIZE) * CanvasHelper.GRID_SIZE
+    if (this.plugin.settings.getSetting('autoResizeNodeSnapToGrid')) {
+      const gridSize = this.plugin.settings.getSetting('gridSize') // Added by an LLM agent
+      height = Math.ceil(height / gridSize) * gridSize
+    }
 
     node.setData({
       ...nodeData,

--- a/src/canvas-extensions/better-default-settings-canvas-extension.ts
+++ b/src/canvas-extensions/better-default-settings-canvas-extension.ts
@@ -92,11 +92,12 @@ export default class BetterDefaultSettingsCanvasExtension  extends CanvasExtensi
   private enforceNodeGridAlignment(_canvas: Canvas, node: CanvasNode) {
     if (!this.plugin.settings.getSetting('alignNewNodesToGrid')) return
 
+    const gridSize = this.plugin.settings.getSetting('gridSize') // Added by an LLM agent
     const nodeData = node.getData()
     node.setData({
       ...nodeData,
-      x: CanvasHelper.alignToGrid(nodeData.x),
-      y: CanvasHelper.alignToGrid(nodeData.y)
+      x: CanvasHelper.alignToGrid(nodeData.x, gridSize),
+      y: CanvasHelper.alignToGrid(nodeData.y, gridSize)
     })
   }
 

--- a/src/canvas-extensions/canvas-filter-canvas-extension.ts
+++ b/src/canvas-extensions/canvas-filter-canvas-extension.ts
@@ -1,0 +1,286 @@
+/* Added by an LLM agent */
+import { getAllTags, Notice, TFile } from "obsidian"
+import { AnyCanvasNodeData, CanvasEdgeData, CanvasGroupNodeData, CanvasNodeData, CanvasTextNodeData } from "src/@types/AdvancedJsonCanvas"
+import { Canvas, CanvasEdge, CanvasNode } from "src/@types/Canvas"
+import { ExtendedCachedMetadata } from "src/@types/Obsidian"
+import CanvasHelper from "src/utils/canvas-helper"
+import { AbstractSelectionModal } from "src/utils/modal-helper"
+import CanvasExtension from "./canvas-extension"
+
+/** Applied to hidden nodes/edges - the actual hiding happens in `styles/canvas-filter.scss` */
+const FILTERED_OUT_CLASS = 'advanced-canvas-filtered-out'
+
+const TAG_REGEX = /#[^\s#]+/g
+
+interface ConnectionFilter {
+  id: string
+  name: string
+  /** Follow edges that point away from the already included nodes */
+  outgoing: boolean
+  /** Follow edges that point towards the already included nodes */
+  incoming: boolean
+}
+
+const CONNECTION_FILTERS: ConnectionFilter[] = [
+  { id: 'filter-connected-nodes', name: 'Filter to selection and connected nodes', outgoing: true, incoming: true },
+  { id: 'filter-outgoing-nodes', name: 'Filter to selection and outgoing nodes', outgoing: true, incoming: false },
+  { id: 'filter-incoming-nodes', name: 'Filter to selection and incoming nodes', outgoing: false, incoming: true }
+]
+
+/**
+ * Temporarily hides nodes and edges that don't match a filter (color, tag or connection to the
+ * selection). The filter is purely visual - nothing gets written to the canvas file - and is reset
+ * by the "Reset filter" command or by reopening the canvas.
+ */
+export default class CanvasFilterCanvasExtension extends CanvasExtension {
+  isEnabled() { return 'canvasFilterFeatureEnabled' as const }
+
+  init() {
+    this.plugin.addCommand({
+      id: 'reset-filter',
+      name: 'Reset filter',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (_canvas: Canvas) => true,
+        (canvas: Canvas) => {
+          this.showOnlyNodes(canvas)
+          this.showOnlyEdges(canvas)
+        }
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'filter-by-color',
+      name: 'Filter by color of selection',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => canvas.selection.size > 0,
+        (canvas: Canvas) => this.filterByColor(canvas)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'filter-by-tag',
+      name: 'Filter by tag',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (_canvas: Canvas) => true,
+        (canvas: Canvas) => void this.filterByTag(canvas)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'hide-selection',
+      name: 'Hide selection',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => canvas.selection.size > 0,
+        (canvas: Canvas) => this.hideSelection(canvas, false)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'hide-selection-with-edges',
+      name: 'Hide selection and its edges',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => canvas.selection.size > 0,
+        (canvas: Canvas) => this.hideSelection(canvas, true)
+      )
+    })
+
+    for (const connectionFilter of CONNECTION_FILTERS) {
+      this.plugin.addCommand({
+        id: connectionFilter.id,
+        name: connectionFilter.name,
+        checkCallback: CanvasHelper.canvasCommand(
+          this.plugin,
+          (canvas: Canvas) => canvas.selection.size > 0,
+          (canvas: Canvas) => this.filterByConnections(canvas, connectionFilter)
+        )
+      })
+    }
+  }
+
+  // Visibility helpers
+
+  private setElementsVisibility(elements: (HTMLElement | undefined)[], visible: boolean) {
+    for (const element of elements) element?.classList.toggle(FILTERED_OUT_CLASS, !visible)
+  }
+
+  private setNodeVisibility(node: CanvasNode, visible: boolean) {
+    this.setElementsVisibility([node.nodeEl], visible)
+  }
+
+  private setEdgeVisibility(edge: CanvasEdge, visible: boolean) {
+    this.setElementsVisibility([edge.lineGroupEl, edge.lineEndGroupEl, edge.labelElement?.wrapperEl], visible)
+  }
+
+  /** Shows the nodes with the given ids and hides all others. Shows every node if no ids are given. */
+  private showOnlyNodes(canvas: Canvas, nodeIdsToShow?: Set<string>) {
+    for (const node of canvas.nodes.values())
+      this.setNodeVisibility(node, nodeIdsToShow === undefined || nodeIdsToShow.has(node.id))
+  }
+
+  /** Shows the edges with the given ids and hides all others. Shows every edge if no ids are given. */
+  private showOnlyEdges(canvas: Canvas, edgeIdsToShow?: Set<string>) {
+    for (const edge of canvas.edges.values())
+      this.setEdgeVisibility(edge, edgeIdsToShow === undefined || edgeIdsToShow.has(edge.id))
+  }
+
+  /** Shows the given nodes, the groups containing them and the edges between them - hides everything else */
+  private showOnlyNodesAndTheirEdges(canvas: Canvas, nodesToShow: AnyCanvasNodeData[]) {
+    const canvasData = canvas.getData()
+
+    const nodeIdsToShow = new Set(nodesToShow.map(node => node.id))
+    const edgeIdsToShow = new Set(canvasData.edges
+      .filter(edge => nodeIdsToShow.has(edge.fromNode) && nodeIdsToShow.has(edge.toNode))
+      .map(edge => edge.id))
+
+    for (const group of this.getGroupsContaining(canvasData.nodes, nodesToShow))
+      nodeIdsToShow.add(group.id)
+
+    this.showOnlyNodes(canvas, nodeIdsToShow)
+    this.showOnlyEdges(canvas, edgeIdsToShow)
+  }
+
+  private static bboxContains(outerNode: CanvasNodeData, innerNode: CanvasNodeData) {
+    return outerNode.x <= innerNode.x &&
+      (outerNode.x + outerNode.width) >= (innerNode.x + innerNode.width) &&
+      outerNode.y <= innerNode.y &&
+      (outerNode.y + outerNode.height) >= (innerNode.y + innerNode.height)
+  }
+
+  /** Returns all group nodes that fully contain at least one of the given nodes */
+  private getGroupsContaining(allNodes: AnyCanvasNodeData[], containedNodes: AnyCanvasNodeData[]): CanvasGroupNodeData[] {
+    return allNodes.filter(node => node.type === 'group' &&
+      containedNodes.some(containedNode => CanvasFilterCanvasExtension.bboxContains(node, containedNode))
+    ) as CanvasGroupNodeData[]
+  }
+
+  // Filters
+
+  private filterByColor(canvas: Canvas) {
+    const colorsToShow = new Set([...canvas.selection].map(element => element.getData().color ?? ''))
+    if (colorsToShow.has(''))
+      new Notice('One of the selected elements has no color, so colorless nodes stay visible as well')
+
+    const nodesToShow = canvas.getData().nodes
+      .filter(node => node.type !== 'group' && colorsToShow.has(node.color ?? ''))
+
+    this.showOnlyNodesAndTheirEdges(canvas, nodesToShow)
+  }
+
+  private async filterByTag(canvas: Canvas) {
+    const tags = this.getAvailableTags(canvas)
+    if (tags.length === 0) {
+      new Notice('No tags found in this vault')
+      return
+    }
+
+    const selectedTag = await new AbstractSelectionModal(this.plugin.app, 'Select a tag to filter by...', tags).awaitInput()
+    if (!selectedTag) return
+
+    const nodesToShow = canvas.getData().nodes
+      .filter(node => this.getTagsOfNode(canvas, node).some(tag => CanvasFilterCanvasExtension.tagMatches(tag, selectedTag)))
+
+    this.showOnlyNodesAndTheirEdges(canvas, nodesToShow)
+  }
+
+  private filterByConnections(canvas: Canvas, connectionFilter: ConnectionFilter) {
+    const canvasData = canvas.getData()
+
+    const nodeIdsToShow = new Set([...canvas.selection].map(element => element.id))
+    const edgeIdsToShow = new Set<string>()
+
+    // Traverse the graph breadth-first, starting at the selection
+    let frontier = new Set(nodeIdsToShow)
+    while (frontier.size > 0) {
+      const nextFrontier = new Set<string>()
+
+      for (const edge of canvasData.edges) {
+        let reachedNodeId: string | null = null
+
+        if (connectionFilter.outgoing && frontier.has(edge.fromNode)) reachedNodeId = edge.toNode
+        else if (connectionFilter.incoming && frontier.has(edge.toNode)) reachedNodeId = edge.fromNode
+        else continue
+
+        edgeIdsToShow.add(edge.id)
+
+        if (nodeIdsToShow.has(reachedNodeId)) continue
+        nodeIdsToShow.add(reachedNodeId)
+        nextFrontier.add(reachedNodeId)
+      }
+
+      frontier = nextFrontier
+    }
+
+    for (const group of this.getGroupsContaining(canvasData.nodes, canvasData.nodes.filter(node => nodeIdsToShow.has(node.id))))
+      nodeIdsToShow.add(group.id)
+
+    this.showOnlyNodes(canvas, nodeIdsToShow)
+    this.showOnlyEdges(canvas, edgeIdsToShow)
+  }
+
+  private hideSelection(canvas: Canvas, includeConnectedEdges: boolean) {
+    const selectedIds = new Set([...canvas.selection].map(element => element.id))
+
+    for (const nodeId of selectedIds) {
+      const node = canvas.nodes.get(nodeId)
+      if (node) this.setNodeVisibility(node, false)
+
+      const edge = canvas.edges.get(nodeId)
+      if (edge) this.setEdgeVisibility(edge, false)
+    }
+
+    if (includeConnectedEdges) {
+      for (const edge of canvas.edges.values()) {
+        const edgeData: CanvasEdgeData = edge.getData()
+        if (!selectedIds.has(edgeData.fromNode) && !selectedIds.has(edgeData.toNode)) continue
+
+        this.setEdgeVisibility(edge, false)
+      }
+    }
+
+    canvas.deselectAll()
+  }
+
+  // Tag helpers
+
+  /** All tags of the vault, plus the ones that only exist inside text nodes of this canvas */
+  private getAvailableTags(canvas: Canvas): string[] {
+    const vaultTags = Object.keys(this.plugin.app.metadataCache.getTags() ?? {})
+    const canvasTags = canvas.getData().nodes.flatMap(node => this.getTagsOfNode(canvas, node))
+
+    return [...new Set([...vaultTags, ...canvasTags])].sort((a, b) => a.localeCompare(b))
+  }
+
+  private getTagsOfNode(canvas: Canvas, nodeData: AnyCanvasNodeData): string[] {
+    if (nodeData.type === 'file') {
+      const file = canvas.nodes.get(nodeData.id)?.file
+      if (!(file instanceof TFile)) return []
+
+      const fileMetadata = this.plugin.app.metadataCache.getFileCache(file)
+      if (!fileMetadata) return []
+
+      return getAllTags(fileMetadata) ?? []
+    }
+
+    if (nodeData.type === 'text') {
+      // Prefer the per-node metadata created by the metadata cache patcher - it also knows about frontmatter tags
+      const canvasFile = canvas.view.file
+      const canvasMetadata = canvasFile ? this.plugin.app.metadataCache.getFileCache(canvasFile) as ExtendedCachedMetadata | null : null
+      const nodeMetadata = canvasMetadata?.nodes?.[nodeData.id]
+      if (nodeMetadata) return getAllTags(nodeMetadata) ?? []
+
+      return [...(nodeData as CanvasTextNodeData).text.matchAll(TAG_REGEX)].map(match => match[0])
+    }
+
+    return []
+  }
+
+  /** Matches nested tags as well - e.g. the filter `#project` includes `#project/canvas` */
+  private static tagMatches(tag: string, filterTag: string) {
+    return tag === filterTag || tag.startsWith(`${filterTag}/`)
+  }
+}

--- a/src/canvas-extensions/canvas-filter-canvas-extension.ts
+++ b/src/canvas-extensions/canvas-filter-canvas-extension.ts
@@ -1,11 +1,12 @@
 /* Added by an LLM agent */
 import { getAllTags, Notice, TFile } from "obsidian"
-import { AnyCanvasNodeData, CanvasEdgeData, CanvasGroupNodeData, CanvasNodeData, CanvasTextNodeData } from "src/@types/AdvancedJsonCanvas"
+import { AnyCanvasNodeData, CanvasEdgeData, CanvasFileNodeData, CanvasGroupNodeData, CanvasNodeData, CanvasTextNodeData } from "src/@types/AdvancedJsonCanvas"
 import { Canvas, CanvasEdge, CanvasNode } from "src/@types/Canvas"
 import { ExtendedCachedMetadata } from "src/@types/Obsidian"
 import CanvasHelper from "src/utils/canvas-helper"
 import { AbstractSelectionModal } from "src/utils/modal-helper"
 import CanvasExtension from "./canvas-extension"
+import PortalsCanvasExtension from "./portals-canvas-extension" // Added by an LLM agent
 
 /** Applied to hidden nodes/edges - the actual hiding happens in `styles/canvas-filter.scss` */
 const FILTERED_OUT_CLASS = 'advanced-canvas-filtered-out'
@@ -19,10 +20,13 @@ interface ConnectionFilter {
   outgoing: boolean
   /** Follow edges that point towards the already included nodes */
   incoming: boolean
+  /** Added by an LLM agent - only follow edges one hop away from the selection, not the whole connected component */
+  immediate?: boolean
 }
 
 const CONNECTION_FILTERS: ConnectionFilter[] = [
   { id: 'filter-connected-nodes', name: 'Filter to selection and connected nodes', outgoing: true, incoming: true },
+  { id: 'filter-immediately-connected-nodes', name: 'Filter to selection and immediately connected nodes', outgoing: true, incoming: true, immediate: true }, // Added by an LLM agent
   { id: 'filter-outgoing-nodes', name: 'Filter to selection and outgoing nodes', outgoing: true, incoming: false },
   { id: 'filter-incoming-nodes', name: 'Filter to selection and incoming nodes', outgoing: false, incoming: true }
 ]
@@ -130,18 +134,35 @@ export default class CanvasFilterCanvasExtension extends CanvasExtension {
 
   /** Shows the given nodes, the groups containing them and the edges between them - hides everything else */
   private showOnlyNodesAndTheirEdges(canvas: Canvas, nodesToShow: AnyCanvasNodeData[]) {
-    const canvasData = canvas.getData()
+    // Added by an LLM agent - use the live nodes/edges: canvas.getData() strips portal elements
+    const nodes = [...canvas.nodes.values()].map(node => node.getData())
+    const edges = [...canvas.edges.values()].map(edge => edge.getData())
 
     const nodeIdsToShow = new Set(nodesToShow.map(node => node.id))
-    const edgeIdsToShow = new Set(canvasData.edges
+    const edgeIdsToShow = new Set(edges
       .filter(edge => nodeIdsToShow.has(edge.fromNode) && nodeIdsToShow.has(edge.toNode))
       .map(edge => edge.id))
 
-    for (const group of this.getGroupsContaining(canvasData.nodes, nodesToShow))
+    for (const group of this.getGroupsContaining(nodes, nodesToShow))
       nodeIdsToShow.add(group.id)
 
     this.showOnlyNodes(canvas, nodeIdsToShow)
     this.showOnlyEdges(canvas, edgeIdsToShow)
+  }
+
+  // Added by an LLM agent
+  /** All live nodes nested inside the given portal (at any depth) */
+  private static getPortalNestedNodes(nodes: AnyCanvasNodeData[], portalId: string) {
+    return nodes.filter(node => node.id !== portalId &&
+      PortalsCanvasExtension.getNestedIds(node.id).contains(portalId))
+  }
+
+  // Added by an LLM agent
+  /** All live edges with both endpoints nested inside the given portal */
+  private static getPortalInternalEdges(edges: CanvasEdgeData[], portalId: string) {
+    return edges.filter(edge =>
+      PortalsCanvasExtension.getNestedIds(edge.fromNode).contains(portalId) &&
+      PortalsCanvasExtension.getNestedIds(edge.toNode).contains(portalId))
   }
 
   private static bboxContains(outerNode: CanvasNodeData, innerNode: CanvasNodeData) {
@@ -165,8 +186,28 @@ export default class CanvasFilterCanvasExtension extends CanvasExtension {
     if (colorsToShow.has(''))
       new Notice('One of the selected elements has no color, so colorless nodes stay visible as well')
 
-    const nodesToShow = canvas.getData().nodes
-      .filter(node => node.type !== 'group' && colorsToShow.has(node.color ?? ''))
+    // Added by an LLM agent
+    // Use the live nodes instead of canvas.getData() (which strips portal elements) and
+    // expand every color-matching portal so its entire content stays visible
+    const nodes = [...canvas.nodes.values()].map(node => node.getData())
+
+    const nodesToShow = nodes.filter(node =>
+      node.type !== 'group' &&
+      !PortalsCanvasExtension.isPortalElement(node.id) &&
+      colorsToShow.has(node.color ?? ''))
+
+    // Index-based loop - matching nested portals get appended and expanded as well
+    const shownNodeIds = new Set(nodesToShow.map(node => node.id))
+    for (let i = 0; i < nodesToShow.length; i++) {
+      const node = nodesToShow[i]
+      if (node.type !== 'file' || !(node as CanvasFileNodeData).portal) continue
+
+      for (const nestedNode of CanvasFilterCanvasExtension.getPortalNestedNodes(nodes, node.id)) {
+        if (shownNodeIds.has(nestedNode.id)) continue
+        shownNodeIds.add(nestedNode.id)
+        nodesToShow.push(nestedNode)
+      }
+    }
 
     this.showOnlyNodesAndTheirEdges(canvas, nodesToShow)
   }
@@ -188,17 +229,25 @@ export default class CanvasFilterCanvasExtension extends CanvasExtension {
   }
 
   private filterByConnections(canvas: Canvas, connectionFilter: ConnectionFilter) {
-    const canvasData = canvas.getData()
+    // Added by an LLM agent
+    // Use the live nodes/edges instead of canvas.getData() - getData() strips all portal
+    // elements (see PortalsCanvasExtension.onGetData), which made this filter incompatible
+    // with portals. Live portal elements look like normal nodes/edges with
+    // 'acportal||'-prefixed ids, so traversing into a portal works like normal traversal.
+    const nodes = [...canvas.nodes.values()].map(node => node.getData())
+    const edges = [...canvas.edges.values()].map(edge => edge.getData())
 
     const nodeIdsToShow = new Set([...canvas.selection].map(element => element.id))
     const edgeIdsToShow = new Set<string>()
+    const expandedPortalIds = new Set<string>()
+    const expandedGroupIds = new Set<string>() // Added by an LLM agent
 
     // Traverse the graph breadth-first, starting at the selection
     let frontier = new Set(nodeIdsToShow)
     while (frontier.size > 0) {
       const nextFrontier = new Set<string>()
 
-      for (const edge of canvasData.edges) {
+      for (const edge of edges) {
         let reachedNodeId: string | null = null
 
         if (connectionFilter.outgoing && frontier.has(edge.fromNode)) reachedNodeId = edge.toNode
@@ -212,11 +261,56 @@ export default class CanvasFilterCanvasExtension extends CanvasExtension {
         nextFrontier.add(reachedNodeId)
       }
 
+      // Added by an LLM agent
+      // Reaching an open portal node means reaching its entire content - reveal all nested
+      // nodes/edges and keep traversing from them (this also expands nested portals)
+      for (const node of nodes) {
+        if (!nodeIdsToShow.has(node.id) || expandedPortalIds.has(node.id)) continue
+        if (node.type !== 'file' || !(node as CanvasFileNodeData).portal) continue
+        expandedPortalIds.add(node.id)
+
+        for (const nestedNode of CanvasFilterCanvasExtension.getPortalNestedNodes(nodes, node.id)) {
+          if (nodeIdsToShow.has(nestedNode.id)) continue
+          nodeIdsToShow.add(nestedNode.id)
+          nextFrontier.add(nestedNode.id)
+        }
+
+        for (const edge of CanvasFilterCanvasExtension.getPortalInternalEdges(edges, node.id))
+          edgeIdsToShow.add(edge.id)
+      }
+
+      // Added by an LLM agent
+      // Reaching a group node means reaching its entire content - reveal all contained
+      // nodes and keep traversing from them (bbox containment also covers nested groups)
+      for (const node of nodes) {
+        if (!nodeIdsToShow.has(node.id) || expandedGroupIds.has(node.id)) continue
+        if (node.type !== 'group') continue
+        expandedGroupIds.add(node.id)
+
+        for (const containedNode of nodes) {
+          if (containedNode.id === node.id || nodeIdsToShow.has(containedNode.id)) continue
+          if (!CanvasFilterCanvasExtension.bboxContains(node, containedNode)) continue
+
+          nodeIdsToShow.add(containedNode.id)
+          nextFrontier.add(containedNode.id)
+        }
+      }
+
+      if (connectionFilter.immediate) break // Added by an LLM agent - stop after the first hop
+
       frontier = nextFrontier
     }
 
-    for (const group of this.getGroupsContaining(canvasData.nodes, canvasData.nodes.filter(node => nodeIdsToShow.has(node.id))))
+    for (const group of this.getGroupsContaining(nodes, nodes.filter(node => nodeIdsToShow.has(node.id))))
       nodeIdsToShow.add(group.id)
+
+    // Added by an LLM agent
+    // Show every edge between visible nodes, not just the ones the traversal followed
+    // (e.g. with edges A->B, A->C and B->C, filtering from A shows B->C as well)
+    for (const edge of edges) {
+      if (nodeIdsToShow.has(edge.fromNode) && nodeIdsToShow.has(edge.toNode))
+        edgeIdsToShow.add(edge.id)
+    }
 
     this.showOnlyNodes(canvas, nodeIdsToShow)
     this.showOnlyEdges(canvas, edgeIdsToShow)

--- a/src/canvas-extensions/commands-canvas-extension.ts
+++ b/src/canvas-extensions/commands-canvas-extension.ts
@@ -1,6 +1,6 @@
 import { TFile } from "obsidian"
 import { CanvasFileNodeData } from "src/@types/AdvancedJsonCanvas"
-import { Canvas, CanvasNode } from "src/@types/Canvas"
+import { Canvas, CanvasEdge, CanvasElement, CanvasNode } from "src/@types/Canvas"
 import { ExtendedCachedMetadata } from "src/@types/Obsidian"
 import BBoxHelper from "src/utils/bbox-helper"
 import CanvasHelper from "src/utils/canvas-helper"
@@ -10,6 +10,26 @@ import CopyNodeReferenceCanvasExtension from "./copy-node-reference-canvas-exten
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 const DIRECTIONS = ['up', 'down', 'left', 'right'] as Direction[]
+
+// Added by an LLM agent
+/** The value the "Invisible" (eye-off) style option sets - see BUILTIN_*_STYLE_ATTRIBUTES. */
+const INVISIBLE_STYLE_VALUE = 'invisible'
+
+/**
+ * Added by an LLM agent.
+ * Which style attribute carries the "Invisible" option per element kind, plus the key the style it
+ * replaced gets parked under - so toggling back restores e.g. a dashed border instead of the default.
+ */
+const INVISIBLE_STYLE_KEYS = {
+  node: { style: 'border', restore: 'borderBeforeInvisible' },
+  edge: { style: 'path', restore: 'pathBeforeInvisible' }
+} as const
+
+// Added by an LLM agent
+type InvisibleStyleTarget = {
+  element: CanvasElement
+  keys: (typeof INVISIBLE_STYLE_KEYS)[keyof typeof INVISIBLE_STYLE_KEYS]
+}
 
 export default class CommandsCanvasExtension extends CanvasExtension {
   isEnabled() { return 'commandsFeatureEnabled' as const }
@@ -22,6 +42,17 @@ export default class CommandsCanvasExtension extends CanvasExtension {
         this.plugin,
         (_canvas: Canvas) => true,
         (canvas: Canvas) => canvas.setReadonly(!canvas.readonly)
+      )
+    })
+
+    // Added by an LLM agent
+    this.plugin.addCommand({
+      id: 'toggle-invisible-style',
+      name: 'Toggle invisible style',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && this.getInvisibleStyleTargets(canvas).length > 0,
+        (canvas: Canvas) => this.toggleInvisibleStyle(canvas)
       )
     })
 
@@ -314,6 +345,62 @@ export default class CommandsCanvasExtension extends CanvasExtension {
         }
       )
     })
+  }
+
+  /**
+   * Added by an LLM agent.
+   * The selected elements the "Invisible" style option can be applied to, paired with the style
+   * attribute that carries it. Nodes/edges are skipped while their styling feature is disabled - the
+   * style attribute never reaches the DOM then, so toggling it would silently do nothing.
+   */
+  private getInvisibleStyleTargets(canvas: Canvas): InvisibleStyleTarget[] {
+    const targets: InvisibleStyleTarget[] = []
+
+    for (const element of canvas.selection) {
+      // Edges are the only selectable elements with a path
+      const kind = (element as CanvasEdge).path !== undefined ? 'edge' : 'node'
+      const featureSetting = kind === 'edge' ? 'edgesStylingFeatureEnabled' : 'nodeStylingFeatureEnabled'
+      if (!this.plugin.settings.getSetting(featureSetting)) continue
+
+      targets.push({ element, keys: INVISIBLE_STYLE_KEYS[kind] })
+    }
+
+    return targets
+  }
+
+  /**
+   * Added by an LLM agent.
+   * Hides the whole selection, unless it is already fully hidden - then it gets restored to whatever
+   * style it had before being hidden.
+   */
+  private toggleInvisibleStyle(canvas: Canvas) {
+    const targets = this.getInvisibleStyleTargets(canvas)
+    if (targets.length === 0) return
+
+    const hide = !targets.every(({ element, keys }) =>
+      element.getData().styleAttributes?.[keys.style] === INVISIBLE_STYLE_VALUE)
+
+    for (const { element, keys } of targets) {
+      const elementData = element.getData()
+      const styleAttributes = elementData.styleAttributes ?? {}
+
+      // Skip elements that are already in the target state - re-hiding an already hidden element
+      // would park "invisible" as its own previous style and strand it there
+      if ((styleAttributes[keys.style] === INVISIBLE_STYLE_VALUE) === hide) continue
+
+      // Unset attributes are set to null instead of being dropped, so the dataset exposer removes
+      // the now-stale data attribute from the DOM
+      element.setData({
+        ...elementData,
+        styleAttributes: {
+          ...styleAttributes,
+          [keys.style]: hide ? INVISIBLE_STYLE_VALUE : (styleAttributes[keys.restore] ?? null),
+          [keys.restore]: hide ? (styleAttributes[keys.style] ?? null) : null
+        }
+      })
+    }
+
+    canvas.pushHistory(canvas.getData())
   }
 
   private createTextNode(canvas: Canvas) {

--- a/src/canvas-extensions/commands-canvas-extension.ts
+++ b/src/canvas-extensions/commands-canvas-extension.ts
@@ -7,6 +7,7 @@ import CanvasHelper from "src/utils/canvas-helper"
 import { FileSelectModal } from "src/utils/modal-helper"
 import CanvasExtension from "./canvas-extension"
 import CopyNodeReferenceCanvasExtension from "./copy-node-reference-canvas-extension"
+import PresentationCanvasExtension from "./presentation-canvas-extension" // Added by an LLM agent
 
 type Direction = 'up' | 'down' | 'left' | 'right'
 const DIRECTIONS = ['up', 'down', 'left', 'right'] as Direction[]
@@ -88,13 +89,21 @@ export default class CommandsCanvasExtension extends CanvasExtension {
       )
     })
 
+    // Added by an LLM agent - while presenting with nothing selected, this refocuses the current slide instead
     this.plugin.addCommand({
       id: 'zoom-to-selection',
       name: 'Zoom to selection',
       checkCallback: CanvasHelper.canvasCommand(
         this.plugin,
-        (canvas: Canvas) => canvas.selection.size > 0,
-        (canvas: Canvas) => canvas.zoomToSelection()
+        (canvas: Canvas) => canvas.selection.size > 0 || this.getPresentationExtension()?.isPresentationMode === true,
+        (canvas: Canvas) => {
+          if (canvas.selection.size > 0) {
+            canvas.zoomToSelection()
+            return
+          }
+
+          this.getPresentationExtension()?.zoomToCurrentSlide(canvas)
+        }
       )
     })
 
@@ -345,6 +354,16 @@ export default class CommandsCanvasExtension extends CanvasExtension {
         }
       )
     })
+  }
+
+  /**
+   * Added by an LLM agent.
+   * Finds the presentation extension instance. Looked up lazily because plugin.canvasExtensions
+   * is only assigned after every extension's constructor (and thus init()) has already run.
+   */
+  private getPresentationExtension(): PresentationCanvasExtension | undefined {
+    return this.plugin.canvasExtensions
+      ?.find(extension => extension instanceof PresentationCanvasExtension) as PresentationCanvasExtension | undefined
   }
 
   /**

--- a/src/canvas-extensions/dataset-exposers/canvas-metadata-exposer.ts
+++ b/src/canvas-extensions/dataset-exposers/canvas-metadata-exposer.ts
@@ -18,7 +18,9 @@ export default class CanvasMetadataExposerExtension extends CanvasExtension {
 
   private updateExposedSettings(canvas: Canvas) {
     // Expose start node
-    const startNodeId = canvas.metadata['startNode']
+    // `canvas.metadata` may not be set yet if MetadataCanvasExtension bailed out for this
+    // canvas (e.g. migration genuinely failed) - don't throw in that case.
+    const startNodeId = canvas.metadata?.['startNode']
     for (const [nodeId, node] of canvas.nodes) {
       if (nodeId === startNodeId) node.nodeEl.dataset.isStartNode = 'true'
       else delete node.nodeEl.dataset.isStartNode

--- a/src/canvas-extensions/dataset-exposers/canvas-wrapper-exposer.ts
+++ b/src/canvas-extensions/dataset-exposers/canvas-wrapper-exposer.ts
@@ -7,6 +7,7 @@ const EXPOSED_SETTINGS: (keyof AdvancedCanvasPluginSettingsValues)[] = [
   'disableFontSizeRelativeToZoom',
   'wrapGroupLabels', // Added by an LLM agent
   'hideGroupLabels', // Added by an LLM agent
+  'boxedNodeLabels', // Added by an LLM agent
   'hideBackgroundGridWhenInReadonly',
   'readingModeFixEnabled',
   'collapsibleGroupsFeatureEnabled',

--- a/src/canvas-extensions/dataset-exposers/canvas-wrapper-exposer.ts
+++ b/src/canvas-extensions/dataset-exposers/canvas-wrapper-exposer.ts
@@ -5,6 +5,8 @@ import CanvasExtension from "../canvas-extension"
 
 const EXPOSED_SETTINGS: (keyof AdvancedCanvasPluginSettingsValues)[] = [
   'disableFontSizeRelativeToZoom',
+  'wrapGroupLabels', // Added by an LLM agent
+  'hideGroupLabels', // Added by an LLM agent
   'hideBackgroundGridWhenInReadonly',
   'readingModeFixEnabled',
   'collapsibleGroupsFeatureEnabled',

--- a/src/canvas-extensions/dataset-exposers/node-exposer.ts
+++ b/src/canvas-extensions/dataset-exposers/node-exposer.ts
@@ -12,6 +12,10 @@ export function getExposedNodeData(settings: SettingsManager): (keyof CanvasNode
   if (settings.getSetting('nodeStylingFeatureEnabled')) exposedData.push('styleAttributes')
   if (settings.getSetting('collapsibleGroupsFeatureEnabled')) exposedData.push('collapsed' satisfies keyof CanvasGroupNodeData as keyof CanvasNodeData)
   if (settings.getSetting('portalsFeatureEnabled')) exposedData.push('isPortalLoaded' as keyof CanvasNodeData)
+  // Added by an LLM agent - Expose the rotation as a data-rotation attribute (also mirrored into
+  // the editing iframe body). data-content-rotation is managed by the rotate node extension
+  // itself, because the effective value includes propagation from containing groups/portals.
+  if (settings.getSetting('nodeRotationFeatureEnabled')) exposedData.push('rotation')
 
   return exposedData
 }

--- a/src/canvas-extensions/default-style-sizes-canvas-extension.ts
+++ b/src/canvas-extensions/default-style-sizes-canvas-extension.ts
@@ -1,0 +1,59 @@
+/* Added by an LLM agent */
+import { Canvas } from "src/@types/Canvas"
+import { AdvancedCanvasPluginSettingsValues } from "src/settings"
+import CanvasExtension from "./canvas-extension"
+
+/**
+ * The settings holding the default value of a style attribute and the data attribute they get
+ * exposed as on the canvas wrapper. The values themselves are applied in
+ * `styles/default-style-sizes.scss`.
+ */
+const DEFAULT_SIZE_SETTINGS: { setting: keyof AdvancedCanvasPluginSettingsValues, datasetKey: string, unchangedValue?: string }[] = [
+  { setting: 'defaultGroupLabelSize', datasetKey: 'defaultGroupLabelSize' },
+  // 1 means a solid fill for the opacity, so it needs its own "leave it alone" value
+  { setting: 'defaultGroupOpacity', datasetKey: 'defaultGroupOpacity', unchangedValue: 'default' },
+  { setting: 'defaultEdgeWidth', datasetKey: 'defaultEdgeWidth' },
+  { setting: 'defaultArrowSize', datasetKey: 'defaultArrowSize' }
+]
+
+/** The value of a setting that leaves the size at Obsidian's own default */
+const UNCHANGED_SIZE = '1'
+
+/**
+ * Exposes the configured default sizes on the canvas wrapper so that elements without an
+ * explicit style attribute (`groupLabelSize`/`groupOpacity`/`edgeWidth`/`arrowSize`) can be
+ * styled by CSS.
+ *
+ * A setting that is left at 1x doesn't get exposed at all - the styles are keyed on the
+ * presence of the data attribute, so Obsidian's own sizing stays completely untouched then.
+ */
+export default class DefaultStyleSizesCanvasExtension extends CanvasExtension {
+  isEnabled() { return true }
+
+  init() {
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:settings-changed',
+      () => {
+        for (const canvas of this.plugin.getCanvases())
+          this.updateDefaultSizes(canvas)
+      }
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:canvas-changed',
+      (canvas: Canvas) => this.updateDefaultSizes(canvas)
+    ))
+  }
+
+  private updateDefaultSizes(canvas: Canvas) {
+    const wrapperEl = canvas.wrapperEl
+    if (!wrapperEl) return
+
+    for (const { setting, datasetKey, unchangedValue } of DEFAULT_SIZE_SETTINGS) {
+      const value = this.plugin.settings.getSetting(setting) as string
+
+      if (value === (unchangedValue ?? UNCHANGED_SIZE)) delete wrapperEl.dataset[datasetKey]
+      else wrapperEl.dataset[datasetKey] = value
+    }
+  }
+}

--- a/src/canvas-extensions/default-style-sizes-canvas-extension.ts
+++ b/src/canvas-extensions/default-style-sizes-canvas-extension.ts
@@ -13,19 +13,59 @@ const DEFAULT_SIZE_SETTINGS: { setting: keyof AdvancedCanvasPluginSettingsValues
   // 1 means a solid fill for the opacity, so it needs its own "leave it alone" value
   { setting: 'defaultGroupOpacity', datasetKey: 'defaultGroupOpacity', unchangedValue: 'default' },
   { setting: 'defaultEdgeWidth', datasetKey: 'defaultEdgeWidth' },
-  { setting: 'defaultArrowSize', datasetKey: 'defaultArrowSize' }
+  { setting: 'defaultArrowSize', datasetKey: 'defaultArrowSize' },
+  // Solid is Obsidian's own border, so it needs its own "leave it alone" value
+  { setting: 'defaultNodeBorder', datasetKey: 'defaultNodeBorder', unchangedValue: 'default' }
 ]
 
 /** The value of a setting that leaves the size at Obsidian's own default */
 const UNCHANGED_SIZE = '1'
 
+/** Consumed by `styles/default-style-sizes.scss` */
+const CARD_PADDING_H_PROPERTY = '--ac-card-padding-h'
+const CARD_PADDING_V_PROPERTY = '--ac-card-padding-v'
+
+// Added by an LLM agent
+/**
+ * Newer Obsidian builds expose `--canvas-color` as a full color and tint groups/labels with
+ * `color-mix(in oklch, var(--canvas-color) …)`, while older ones (e.g. the mobile bundle
+ * obsidian-web runs in the browser) expose it as an `r, g, b` triplet for
+ * `rgba(var(--canvas-color), …)`. A declaration built for the wrong shape is invalid at
+ * computed-value time and computes to `unset` (transparent fills), so the styles key each
+ * shape on a wrapper attribute instead of relying on declaration fallbacks.
+ *
+ * Detected once from Obsidian's own group tint rule (checked on the main document - app.css is
+ * guaranteed to be loaded there) and cached; the build doesn't change mid-session.
+ */
+let canvasColorTriplet: boolean | null = null
+
+function canvasColorFormatIsTriplet(): boolean {
+  if (canvasColorTriplet !== null) return canvasColorTriplet
+
+  canvasColorTriplet = false
+  const walk = (rules: CSSRuleList) => {
+    for (const rule of Array.from(rules)) {
+      if (rule instanceof CSSGroupingRule) walk(rule.cssRules)
+      else if (rule instanceof CSSStyleRule
+        && (rule.selectorText === '.canvas-node-group .canvas-node-content'
+          || rule.selectorText === '.canvas-node.is-themed .canvas-node-content'))
+        canvasColorTriplet = rule.cssText.includes('rgba(var(--canvas-color)')
+    }
+  }
+  for (const sheet of Array.from(document.styleSheets)) {
+    try { walk(sheet.cssRules) } catch { continue } // Cross-origin sheets are unreadable
+  }
+  return canvasColorTriplet
+}
+
 /**
  * Exposes the configured default sizes on the canvas wrapper so that elements without an
- * explicit style attribute (`groupLabelSize`/`groupOpacity`/`edgeWidth`/`arrowSize`) can be
- * styled by CSS.
+ * explicit style attribute (`groupLabelSize`/`groupOpacity`/`edgeWidth`/`arrowSize`/`border`) can
+ * be styled by CSS.
  *
- * A setting that is left at 1x doesn't get exposed at all - the styles are keyed on the
- * presence of the data attribute, so Obsidian's own sizing stays completely untouched then.
+ * A setting that is left at its unchanged value (1x for sizes, 'default' otherwise) doesn't get
+ * exposed at all - the styles are keyed on the presence of the data attribute, so Obsidian's own
+ * styling stays completely untouched then.
  */
 export default class DefaultStyleSizesCanvasExtension extends CanvasExtension {
   isEnabled() { return true }
@@ -55,5 +95,17 @@ export default class DefaultStyleSizesCanvasExtension extends CanvasExtension {
       if (value === (unchangedValue ?? UNCHANGED_SIZE)) delete wrapperEl.dataset[datasetKey]
       else wrapperEl.dataset[datasetKey] = value
     }
+
+    // Card node padding (added by an LLM agent) - a continuous [horizontal, vertical] pixel
+    // pair rather than a discrete preset, so it's exposed as CSS custom properties instead of
+    // a dataset attribute. [16, 0] reproduces Obsidian's own default padding exactly.
+    const [paddingHorizontal, paddingVertical] = this.plugin.settings.getSetting('cardNodePadding') as [number, number]
+    wrapperEl.style.setProperty(CARD_PADDING_H_PROPERTY, `${paddingHorizontal}px`)
+    wrapperEl.style.setProperty(CARD_PADDING_V_PROPERTY, `${paddingVertical}px`)
+
+    // Added by an LLM agent - exposes the --canvas-color value shape; consumed by the group
+    // opacity and boxed node label rules in node-styles.scss / default-style-sizes.scss
+    if (canvasColorFormatIsTriplet()) wrapperEl.dataset.canvasColorFormat = 'triplet'
+    else delete wrapperEl.dataset.canvasColorFormat
   }
 }

--- a/src/canvas-extensions/edge-arrow-base-canvas-extension.ts
+++ b/src/canvas-extensions/edge-arrow-base-canvas-extension.ts
@@ -1,0 +1,213 @@
+/* Added by an LLM agent */
+import { Side } from "src/@types/AdvancedJsonCanvas"
+import { Canvas, CanvasEdge, Position } from "src/@types/Canvas"
+import BBoxHelper from "src/utils/bbox-helper"
+import CanvasExtension from "./canvas-extension"
+
+/**
+ * How far the triangle arrow head reaches back from its tip before any scaling - the `y` of the
+ * two back corners of the `0,0 6.5,10.4 -6.5,10.4` polygon (see
+ * `EdgeStylesExtension.getArrowPolygonPoints`).
+ */
+const TRIANGLE_ARROW_LENGTH = 10.4
+
+/**
+ * The arrow styles whose back edge sits at `TRIANGLE_ARROW_LENGTH`. Every other style (diamonds,
+ * circles, ...) is left alone, because the line has to reach a different distance into it.
+ * `undefined`/`null` is Obsidian's own arrow head, which is the same triangle.
+ */
+const TRIANGLE_ARROW_STYLES: (string | undefined | null)[] = [undefined, null, 'triangle', 'triangle-outline']
+
+/** How far in front of the node border Obsidian ends an edge path that has an arrow head */
+const DEFAULT_PATH_END_OFFSET = 7
+
+/**
+ * The share of the distance between the two node borders the ends may be pulled back by in total.
+ * Zoomed far out an arrow head can be longer than a short edge, and pulling both ends back that
+ * far would turn the path inside out - such edges fall back towards Obsidian's own geometry
+ * instead.
+ */
+const MAX_TOTAL_OFFSET_RATIO = 0.45
+
+/** The unit vector pointing away from the node, out of the middle of the given side */
+function getOutwardSideVector(side: Side): Position {
+  switch (side) {
+    case 'top': return { x: 0, y: -1 }
+    case 'right': return { x: 1, y: 0 }
+    case 'bottom': return { x: 0, y: 1 }
+    case 'left': return { x: -1, y: 0 }
+  }
+}
+
+function movedAlong(position: Position, direction: Position, distance: number): Position {
+  return { x: position.x + direction.x * distance, y: position.y + direction.y * distance }
+}
+
+/**
+ * Makes an edge end at the back of its arrow head instead of at the node border.
+ *
+ * Obsidian ends every edge path 7 units in front of the node border and then puts the arrow head
+ * on the border itself, pointing along the side's normal. An arrow head reaches much further back
+ * than those 7 units (even more so once the arrow size feature enlarges it), so a line that
+ * arrives at an angle passes the arrow's back edge well off to one side of it and only then runs
+ * out - the arrow ends up looking stuck to the line off-centre. Aiming the path at the middle of
+ * the back edge instead makes the line meet the arrow head centred, whatever direction it comes
+ * from.
+ *
+ * Only the two ends of the path are moved; the arrow heads themselves stay exactly where Obsidian
+ * put them. Because an arrow head's size in canvas units depends on the zoom level, the paths are
+ * also recalculated whenever the viewport settles at a new zoom.
+ */
+export default class EdgeArrowBaseCanvasExtension extends CanvasExtension {
+  private pendingZoomRefreshes = new Map<Canvas, number>()
+  private appliedZoomMultipliers = new WeakMap<Canvas, number>()
+
+  isEnabled() { return true }
+
+  init() {
+    this.plugin.register(() => {
+      for (const frame of this.pendingZoomRefreshes.values()) window.cancelAnimationFrame(frame)
+      this.pendingZoomRefreshes.clear()
+    })
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-path-updated',
+      (canvas: Canvas, edge: CanvasEdge) => this.onEdgePathUpdated(canvas, edge)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:viewport-changed:after',
+      (canvas: Canvas) => this.scheduleZoomRefresh(canvas)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:settings-changed',
+      () => {
+        for (const canvas of this.plugin.getCanvases()) this.rerenderEdges(canvas)
+      }
+    ))
+  }
+
+  /**
+   * Moves the ends of the path Obsidian just calculated out to the middle of the back edge of the
+   * arrow heads. The control points move along with them, so the curve keeps its shape and still
+   * meets the arrow head from the same direction.
+   *
+   * Runs on every `updatePath`, which includes the one the edge styles extension does before it
+   * builds a pathfinding path - those read the updated `bezier` and end up at the arrow base too.
+   */
+  private onEdgePathUpdated(canvas: Canvas, edge: CanvasEdge) {
+    if (!this.plugin.settings.getSetting('connectEdgesToArrowBase')) return
+    if (!edge.bezier || !edge.path?.display) return
+
+    const arrowLength = this.getArrowLength(canvas, edge)
+    if (arrowLength === null) return
+
+    // An arrow head shorter than Obsidian's own offset would need the line to grow instead
+    const offset = Math.max(0, arrowLength - DEFAULT_PATH_END_OFFSET)
+    if (offset === 0) return
+
+    const fromBorder = BBoxHelper.getCenterOfBBoxSide(edge.from.node.getBBox(), edge.from.side)
+    const toBorder = BBoxHelper.getCenterOfBBoxSide(edge.to.node.getBBox(), edge.to.side)
+
+    const endCount = (edge.fromLineEnd ? 1 : 0) + (edge.toLineEnd ? 1 : 0)
+    if (endCount === 0) return
+
+    const span = Math.hypot(toBorder.x - fromBorder.x, toBorder.y - fromBorder.y)
+    const cappedOffset = Math.min(offset, (span * MAX_TOTAL_OFFSET_RATIO) / endCount)
+
+    const fromOffset = edge.fromLineEnd ? cappedOffset : 0
+    const toOffset = edge.toLineEnd ? cappedOffset : 0
+
+    const fromAxis = getOutwardSideVector(edge.from.side)
+    const toAxis = getOutwardSideVector(edge.to.side)
+
+    const from = movedAlong(edge.bezier.from, fromAxis, fromOffset)
+    const cp1 = movedAlong(edge.bezier.cp1, fromAxis, fromOffset)
+    const to = movedAlong(edge.bezier.to, toAxis, toOffset)
+    const cp2 = movedAlong(edge.bezier.cp2, toAxis, toOffset)
+    const curve = `M${from.x},${from.y} C${cp1.x},${cp1.y} ${cp2.x},${cp2.y} ${to.x},${to.y}`
+
+    Object.assign(edge.bezier, { from, cp1, to, cp2, path: curve })
+
+    // Same as Obsidian's own path: an end without an arrow head gets a stub out to the node border
+    let path = curve
+    if (!edge.fromLineEnd) path = `M${fromBorder.x} ${fromBorder.y} L${from.x} ${from.y} ${path}`
+    if (!edge.toLineEnd) path = `${path} M${to.x} ${to.y} L${toBorder.x} ${toBorder.y}`
+
+    edge.path.interaction.setAttribute('d', path)
+    edge.path.display.setAttribute('d', path)
+  }
+
+  /** How far the edge's arrow heads reach back in canvas units, or null if they aren't triangles */
+  private getArrowLength(canvas: Canvas, edge: CanvasEdge): number | null {
+    // Without the edge styles feature the style attributes are ignored, so every arrow head is
+    // Obsidian's own triangle at the default size
+    const styleAttributes = this.plugin.settings.getSetting('edgesStylingFeatureEnabled')
+      ? edge.getData()?.styleAttributes
+      : undefined
+
+    if (!TRIANGLE_ARROW_STYLES.includes(styleAttributes?.arrow)) return null
+
+    // Mirrors the arrow size feature's `--arrow-size-multiplier`/`--default-arrow-size-multiplier`
+    // (see styles/edge-styles.scss and styles/default-style-sizes.scss)
+    const arrowSize = Number.parseFloat(
+      String(styleAttributes?.arrowSize ?? this.plugin.settings.getSetting('defaultArrowSize'))
+    ) || 1
+
+    return TRIANGLE_ARROW_LENGTH * this.getZoomMultiplier(canvas) * arrowSize
+  }
+
+  /** The `--zoom-multiplier` Obsidian scales the arrow polygon (and everything else) by */
+  private getZoomMultiplier(canvas: Canvas): number {
+    const zoomMultiplier = Number.parseFloat(canvas.wrapperEl?.style.getPropertyValue('--zoom-multiplier'))
+    return Number.isFinite(zoomMultiplier) && zoomMultiplier > 0
+      ? zoomMultiplier
+      : Math.sqrt(1 / Math.pow(2, canvas.zoom))
+  }
+
+  /**
+   * Recalculates the paths once the viewport has come to rest, if zooming changed how long the
+   * arrow heads are. `--zoom-multiplier` is only written when the viewport animation finishes, so
+   * there is nothing to read (and nothing worth recalculating) while it is still moving - hence
+   * waiting it out frame by frame.
+   */
+  private scheduleZoomRefresh(canvas: Canvas) {
+    if (this.pendingZoomRefreshes.has(canvas)) return
+
+    const waitForViewport = () => {
+      if (!canvas.canvasEl?.isConnected) {
+        this.pendingZoomRefreshes.delete(canvas)
+        return
+      }
+
+      if (canvas.viewportChanged) {
+        this.pendingZoomRefreshes.set(canvas, window.requestAnimationFrame(waitForViewport))
+        return
+      }
+
+      this.pendingZoomRefreshes.delete(canvas)
+
+      const zoomMultiplier = this.getZoomMultiplier(canvas)
+      if (zoomMultiplier === this.appliedZoomMultipliers.get(canvas)) return
+      this.appliedZoomMultipliers.set(canvas, zoomMultiplier)
+
+      this.rerenderEdges(canvas)
+    }
+
+    this.pendingZoomRefreshes.set(canvas, window.requestAnimationFrame(waitForViewport))
+  }
+
+  /**
+   * Queues a redraw of every edge that is currently on screen - the rest gets drawn on its way in.
+   *
+   * Marking them dirty rather than calling `render` directly is what the edge styles extension
+   * expects: it only rebuilds a pathfinding path for edges in `canvas.dirty`, so a bare `render`
+   * would drop the path back to the default bezier.
+   */
+  private rerenderEdges(canvas: Canvas) {
+    for (const edge of canvas.edges.values()) {
+      if (edge.initialized && edge.path?.display.isConnected) canvas.markDirty(edge)
+    }
+  }
+}

--- a/src/canvas-extensions/edge-label-markdown-canvas-extension.ts
+++ b/src/canvas-extensions/edge-label-markdown-canvas-extension.ts
@@ -1,0 +1,266 @@
+/* Added by an LLM agent */
+import { Component, MarkdownRenderer } from "obsidian"
+import { Canvas, CanvasEdge, CanvasEdgeLabelElement, CanvasView, Position } from "src/@types/Canvas"
+import Patcher from "src/patchers/patcher"
+import { isEmbedOnlyLabel } from "src/utils/edge-label-embed-helper"
+import CanvasExtension from "./canvas-extension"
+
+/** Set on the label while it shows rendered markdown instead of its raw source */
+const RENDERED_CLASS = 'ac-markdown-label'
+
+/**
+ * Set on top of `RENDERED_CLASS` when the label contains content that has no intrinsic width
+ * (embeds, code block widgets, tables, images). Those collapse to a few pixels inside the
+ * label's shrink-to-fit box, so the label needs a definite width instead.
+ */
+const BLOCK_CONTENT_CLASS = 'ac-markdown-label-block'
+
+const BLOCK_CONTENT_SELECTOR = '.internal-embed, .external-embed, [class*="block-language-"], table, img, iframe, video, canvas, .callout'
+
+/** Consumed by `styles/edge-label-markdown.scss` */
+const MAX_WIDTH_PROPERTY = '--ac-markdown-label-max-width'
+const MAX_HEIGHT_PROPERTY = '--ac-markdown-label-max-height'
+
+/**
+ * Elements that should stay interactive inside a rendered label. A click on one of these
+ * must not bubble to the core click handler on the label wrapper, because that handler
+ * selects the edge / enters edit mode and would swallow the interaction.
+ */
+const INTERACTIVE_SELECTOR = 'a, .internal-embed, .external-embed, .task-list-item-checkbox, button, input, .callout-fold, .copy-code-button'
+
+/**
+ * Renders edge labels as markdown.
+ *
+ * The core label is a `contenteditable` div holding the raw label text. This extension swaps
+ * that text for rendered markdown whenever the label isn't being edited, and swaps the raw
+ * source back in before edit mode starts, so typing still edits the actual label string.
+ */
+export default class EdgeLabelMarkdownCanvasExtension extends CanvasExtension {
+  isEnabled() { return 'edgeLabelMarkdownEnabled' as const }
+
+  /** The label source that is currently rendered, per label - guards against redundant re-renders */
+  private renderedSources = new WeakMap<CanvasEdgeLabelElement, string>()
+  /** Owns the lifecycle of everything `MarkdownRenderer` created for a label (embeds, code blocks, ...) */
+  private renderComponents = new WeakMap<CanvasEdgeLabelElement, Component>()
+  /** The capture-phase click interceptor installed on a label wrapper */
+  private clickInterceptors = new WeakMap<CanvasEdgeLabelElement, (event: MouseEvent) => void>()
+
+  /** The core label class isn't exported, so its prototype gets patched lazily via the first instance */
+  private labelPrototypePatched = false
+
+  init() {
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-added',
+      (_canvas: Canvas, edge: CanvasEdge) => this.onEdgeChanged(edge)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-changed',
+      (_canvas: Canvas, edge: CanvasEdge) => this.onEdgeChanged(edge)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-removed',
+      (_canvas: Canvas, edge: CanvasEdge) => this.cleanupLabel(edge.labelElement)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:canvas-view-unloaded:before',
+      (view: CanvasView) => {
+        for (const edge of view.canvas.edges.values()) this.cleanupLabel(edge.labelElement)
+      }
+    ))
+
+    // Switching the render mode (or the size limits) has to reach labels that are already
+    // rendered - nothing else would invalidate them, because their source hasn't changed
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:settings-changed',
+      () => {
+        for (const canvas of this.plugin.getCanvases()) {
+          for (const edge of canvas.edges.values()) {
+            if (!edge.labelElement) continue
+
+            this.renderedSources.delete(edge.labelElement)
+            void this.renderMarkdown(edge.labelElement)
+          }
+        }
+      }
+    ))
+  }
+
+  private onEdgeChanged(edge: CanvasEdge) {
+    const labelElement = edge.labelElement
+    if (!labelElement) return
+
+    this.patchLabelPrototype(labelElement)
+    this.interceptClicks(labelElement)
+    void this.renderMarkdown(labelElement)
+  }
+
+  /**
+   * Edit mode and destruction aren't exposed as canvas events, so the core label class gets
+   * patched directly. Patching happens once, on the prototype, so it covers every label.
+   */
+  private patchLabelPrototype(labelElement: CanvasEdgeLabelElement) {
+    if (this.labelPrototypePatched) return
+    this.labelPrototypePatched = true
+
+    const that = this // eslint-disable-line @typescript-eslint/no-this-alias -- For patcher
+
+    Patcher.patchPrototype<CanvasEdgeLabelElement>(this.plugin, labelElement, {
+      // Put the raw source back before the caret gets placed into the label
+      focus: Patcher.OverrideExisting(next => function (position?: Position): void {
+        that.showSource(this)
+        next.call(this, position)
+      }),
+
+      // Re-render as soon as editing ends
+      blur: Patcher.OverrideExisting(next => function (): void {
+        next.call(this)
+        void that.renderMarkdown(this)
+      }),
+
+      /**
+       * Core calls this from `edge.render()` - unconditionally, on every render - and it writes
+       * the raw label text straight into `textareaEl`. Left alone it wipes the rendered markdown
+       * the next time anything re-renders the edge (a connected node moving, a style change, a
+       * colour change), and the label stays raw until its source changes. So when the rendered
+       * output for exactly this text is already in place, core's write is skipped entirely.
+       */
+      setText: Patcher.OverrideExisting(next => function (text: string): void {
+        if (!this.isEditing && that.renderedSources.get(this) === text) return
+
+        next.call(this, text)
+        void that.renderMarkdown(this)
+      }),
+
+      destroy: Patcher.OverrideExisting(next => function (skipSave?: boolean): void {
+        that.cleanupLabel(this)
+        next.call(this, skipSave)
+      })
+    })
+  }
+
+  /**
+   * The core click handler on the wrapper selects the edge or enters edit mode. Clicks on
+   * links, embeds and other interactive content get stopped before they reach it - a capture
+   * listener on the same element runs before the bubble listener core registered.
+   */
+  private interceptClicks(labelElement: CanvasEdgeLabelElement) {
+    if (this.clickInterceptors.has(labelElement)) return
+
+    const interceptor = (event: MouseEvent) => {
+      if (labelElement.isEditing) return
+      if (!labelElement.textareaEl.hasClass(RENDERED_CLASS)) return
+
+      const target = event.target as HTMLElement | null
+      if (!target?.closest?.(INTERACTIVE_SELECTOR)) return
+
+      event.stopPropagation()
+    }
+
+    labelElement.wrapperEl.addEventListener('click', interceptor, { capture: true })
+    this.clickInterceptors.set(labelElement, interceptor)
+  }
+
+  /**
+   * Whether this label's source is one the current render mode handles. `embeds-only` limits
+   * rendering to labels that are nothing but note embeds; everything else stays plain text.
+   */
+  private shouldRender(source: string): boolean {
+    if (source.length === 0) return false
+    if (this.plugin.settings.getSetting('edgeLabelMarkdownRenderMode') === 'full') return true
+
+    return isEmbedOnlyLabel(source)
+  }
+
+  /** Replaces the label's content with rendered markdown (no-op while it's being edited) */
+  private async renderMarkdown(labelElement: CanvasEdgeLabelElement) {
+    if (labelElement.isEditing) return
+
+    const source = labelElement.edge.label ?? ''
+    if (this.renderedSources.get(labelElement) === source) return
+
+    const textareaEl = labelElement.textareaEl
+
+    if (!this.shouldRender(source)) {
+      // Nothing to render - hand the label back to core, plain text and all. The source is
+      // deliberately left out of `renderedSources` so core's own `setText` keeps working.
+      this.unloadRenderComponent(labelElement)
+      this.renderedSources.delete(labelElement)
+
+      textareaEl.removeClass(RENDERED_CLASS)
+      textareaEl.removeClass(BLOCK_CONTENT_CLASS)
+      textareaEl.setText(source)
+      return
+    }
+
+    this.renderedSources.set(labelElement, source)
+
+    const component = this.resetRenderComponent(labelElement)
+    textareaEl.empty()
+
+    textareaEl.addClass(RENDERED_CLASS)
+    textareaEl.style.setProperty(MAX_WIDTH_PROPERTY, `${this.plugin.settings.getSetting('edgeLabelMarkdownMaxWidth')}px`)
+    textareaEl.style.setProperty(MAX_HEIGHT_PROPERTY, `${this.plugin.settings.getSetting('edgeLabelMarkdownMaxHeight')}px`)
+
+    const sourcePath = labelElement.edge.canvas.view.file?.path ?? ''
+    try {
+      await MarkdownRenderer.render(this.plugin.app, source, textareaEl, sourcePath, component)
+    } catch (error) {
+      console.error('Advanced Canvas: failed to render an edge label as markdown', error)
+
+      // Fall back to plain text, and give the source back so core's `setText` works again
+      this.unloadRenderComponent(labelElement)
+      this.renderedSources.delete(labelElement)
+
+      textareaEl.removeClass(RENDERED_CLASS)
+      textareaEl.removeClass(BLOCK_CONTENT_CLASS)
+      textareaEl.setText(source)
+      return
+    }
+
+    // The label may have been edited or destroyed while the markdown was rendering
+    if (this.renderComponents.get(labelElement) !== component) return
+
+    textareaEl.toggleClass(BLOCK_CONTENT_CLASS, textareaEl.querySelector(BLOCK_CONTENT_SELECTOR) !== null)
+  }
+
+  /** Puts the raw label source back so it can be edited as plain text */
+  private showSource(labelElement: CanvasEdgeLabelElement) {
+    this.unloadRenderComponent(labelElement)
+    this.renderedSources.delete(labelElement)
+
+    labelElement.textareaEl.removeClass(RENDERED_CLASS)
+    labelElement.textareaEl.removeClass(BLOCK_CONTENT_CLASS)
+    labelElement.textareaEl.setText(labelElement.edge.label ?? '')
+  }
+
+  private resetRenderComponent(labelElement: CanvasEdgeLabelElement): Component {
+    this.unloadRenderComponent(labelElement)
+
+    const component = new Component()
+    this.renderComponents.set(labelElement, component)
+    component.load()
+
+    return component
+  }
+
+  private unloadRenderComponent(labelElement: CanvasEdgeLabelElement) {
+    this.renderComponents.get(labelElement)?.unload()
+    this.renderComponents.delete(labelElement)
+  }
+
+  private cleanupLabel(labelElement: CanvasEdgeLabelElement | null | undefined) {
+    if (!labelElement) return
+
+    this.unloadRenderComponent(labelElement)
+    this.renderedSources.delete(labelElement)
+
+    const interceptor = this.clickInterceptors.get(labelElement)
+    if (interceptor) {
+      labelElement.wrapperEl.removeEventListener('click', interceptor, { capture: true })
+      this.clickInterceptors.delete(labelElement)
+    }
+  }
+}

--- a/src/canvas-extensions/group-label-visibility-canvas-extension.ts
+++ b/src/canvas-extensions/group-label-visibility-canvas-extension.ts
@@ -1,0 +1,33 @@
+/* Added by an LLM agent */
+import { Notice } from "obsidian"
+import { Canvas } from "src/@types/Canvas"
+import CanvasHelper from "src/utils/canvas-helper"
+import CanvasExtension from "./canvas-extension"
+
+/**
+ * Toggles the visibility of every group label. The actual hiding is done in
+ * `styles/group-label-visibility.scss`, driven by the `hideGroupLabels` setting that gets
+ * exposed on the canvas wrapper by `dataset-exposers/canvas-wrapper-exposer.ts`.
+ */
+export default class GroupLabelVisibilityCanvasExtension extends CanvasExtension {
+  isEnabled() { return true }
+
+  init() {
+    this.plugin.addCommand({
+      id: 'toggle-group-label-visibility',
+      name: 'Toggle group label visibility',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (_canvas: Canvas) => true,
+        (_canvas: Canvas) => this.toggleGroupLabelVisibility()
+      )
+    })
+  }
+
+  private toggleGroupLabelVisibility() {
+    const hidden = !this.plugin.settings.getSetting('hideGroupLabels')
+    void this.plugin.settings.setSetting({ hideGroupLabels: hidden })
+
+    new Notice(hidden ? 'Group labels hidden' : 'Group labels visible')
+  }
+}

--- a/src/canvas-extensions/group-label-wrap-canvas-extension.ts
+++ b/src/canvas-extensions/group-label-wrap-canvas-extension.ts
@@ -1,0 +1,138 @@
+/* Added by an LLM agent */
+import { CanvasGroupNodeData } from "src/@types/AdvancedJsonCanvas"
+import { Canvas, CanvasNode, CanvasView } from "src/@types/Canvas"
+import CanvasExtension from "./canvas-extension"
+
+/**
+ * The width of a wrapped group label, in unscaled pixels.
+ * Consumed by `styles/group-label-wrap.scss`.
+ */
+const LABEL_WIDTH_PROPERTY = '--wrapped-group-label-width'
+
+/**
+ * A group label is absolutely positioned, so its width is shrink-to-fit:
+ * `min(max-content, max-width)`. As soon as the text is too long for the group, that
+ * evaluates to `max-width` - the label keeps the full allowed width even though the
+ * wrapped lines are shorter than that, which leaves visible empty space next to the text.
+ *
+ * The width of the longest wrapped line can't be expressed in CSS, so it gets measured
+ * here and applied as a custom property.
+ */
+export default class GroupLabelWrapCanvasExtension extends CanvasExtension {
+  isEnabled() { return 'wrapGroupLabels' as const }
+
+  /** The last `--zoom-multiplier` a canvas' labels were measured at */
+  private lastZoomMultipliers = new WeakMap<Canvas, string>()
+  private zoomObservers = new Map<Canvas, MutationObserver>()
+
+  init() {
+    this.plugin.register(() => this.stopObservingZoom())
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:canvas-changed',
+      (canvas: Canvas) => this.observeZoom(canvas)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:canvas-view-unloaded:before',
+      (view: CanvasView) => this.stopObservingZoom(view.canvas)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-rendered',
+      (_canvas: Canvas, node: CanvasNode) => this.updateLabelWidth(node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-changed',
+      (_canvas: Canvas, node: CanvasNode) => this.updateLabelWidth(node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-resized',
+      (_canvas: Canvas, node: CanvasNode) => this.updateLabelWidth(node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-editing-state-changed',
+      (_canvas: Canvas, node: CanvasNode, _isEditing: boolean) => this.updateLabelWidth(node)
+    ))
+  }
+
+  /**
+   * The label font size and its maximum width both scale with `--zoom-multiplier`, so where
+   * the text wraps changes while zooming out. The viewport events fire before the multiplier
+   * gets applied to the wrapper, so the wrapper itself gets watched instead.
+   */
+  private observeZoom(canvas: Canvas) {
+    this.stopObservingZoom(canvas)
+
+    const observer = new MutationObserver(() => this.onZoomChanged(canvas))
+    observer.observe(canvas.wrapperEl, { attributes: true, attributeFilter: ['style'] })
+    this.zoomObservers.set(canvas, observer)
+
+    this.onZoomChanged(canvas)
+  }
+
+  private stopObservingZoom(canvas?: Canvas) {
+    const canvases = canvas ? [canvas] : [...this.zoomObservers.keys()]
+
+    for (const canvasToStop of canvases) {
+      this.zoomObservers.get(canvasToStop)?.disconnect()
+      this.zoomObservers.delete(canvasToStop)
+    }
+  }
+
+  private onZoomChanged(canvas: Canvas) {
+    const zoomMultiplier = canvas.wrapperEl.style.getPropertyValue('--zoom-multiplier')
+    if (this.lastZoomMultipliers.get(canvas) === zoomMultiplier) return
+    this.lastZoomMultipliers.set(canvas, zoomMultiplier)
+
+    for (const node of canvas.getViewportNodes()) this.updateLabelWidth(node)
+  }
+
+  private updateLabelWidth(node: CanvasNode) {
+    const labelEl = node.labelEl
+    if (!labelEl) return
+
+    const nodeData = node.getData() as CanvasGroupNodeData
+    if (nodeData.type !== 'group') return
+
+    // Measure the natural (shrink-to-fit) layout
+    labelEl.style.removeProperty(LABEL_WIDTH_PROPERTY)
+    if (nodeData.collapsed) return
+
+    const naturalWidth = labelEl.offsetWidth
+    if (naturalWidth === 0) return
+
+    const lineRects = this.getLineRects(labelEl)
+    if (lineRects.length <= 1) return // Not wrapped - shrink-to-fit is already correct
+
+    // The label is scaled by the canvas' zoom, but the width gets applied unscaled
+    const scale = labelEl.getBoundingClientRect().width / naturalWidth
+    if (!scale) return
+
+    const longestLineWidth = Math.max(...lineRects.map(rect => rect.width)) / scale
+    // Round up so that no line gets pushed into another wrap by a subpixel difference
+    const width = Math.ceil(longestLineWidth) + 1 + this.getHorizontalSpacing(labelEl)
+
+    labelEl.style.setProperty(LABEL_WIDTH_PROPERTY, `${width}px`)
+  }
+
+  /** One rect per line box of the label's text */
+  private getLineRects(labelEl: HTMLElement) {
+    const range = labelEl.ownerDocument.createRange()
+    range.selectNodeContents(labelEl)
+
+    return Array.from(range.getClientRects())
+  }
+
+  /** The part of the label's width that isn't taken up by the text itself */
+  private getHorizontalSpacing(labelEl: HTMLElement) {
+    const style = getComputedStyle(labelEl)
+    if (style.boxSizing !== 'border-box') return 0
+
+    const borderWidth = labelEl.offsetWidth - labelEl.clientWidth
+    return borderWidth + parseFloat(style.paddingLeft) + parseFloat(style.paddingRight)
+  }
+}

--- a/src/canvas-extensions/metadata-canvas-extension.ts
+++ b/src/canvas-extensions/metadata-canvas-extension.ts
@@ -1,6 +1,6 @@
 import { Notice } from "obsidian"
 import { Canvas, CanvasView } from "src/@types/Canvas"
-import { CURRENT_SPEC_VERSION } from "src/utils/migration-helper"
+import MigrationHelper, { CURRENT_SPEC_VERSION } from "src/utils/migration-helper"
 import CanvasExtension from "./canvas-extension"
 
 export default class MetadataCanvasExtension extends CanvasExtension {
@@ -27,7 +27,17 @@ export default class MetadataCanvasExtension extends CanvasExtension {
 
   private onCanvasChanged(canvas: Canvas): void {
     /* eslint-disable-next-line @typescript-eslint/no-deprecated -- It's my lint and I know the consequences */
-    const metadata = canvas.data?.metadata
+    if (!canvas.data) return
+
+    // Canvases fed through `Canvas.setData` directly (e.g. other plugins embedding a live,
+    // interactive mini-canvas, such as Better Embedded Canvas) never pass through the patched
+    // `CanvasFileView.setViewData`, so they skip migration entirely. Migrate here too instead of
+    // just warning - `needsMigration`/`migrate` are no-ops for canvases that already migrated
+    // (the normal, unpatched-view-loaded case), so this doesn't change existing behaviour there.
+    if (MigrationHelper.needsMigration(canvas.data))
+      canvas.data = MigrationHelper.migrate(canvas.data)
+
+    const metadata = canvas.data.metadata
     if (!metadata || metadata.version !== CURRENT_SPEC_VERSION)
       return void new Notice("Metadata node not found or version mismatch. Should have been migrated (but wasn't).")
 

--- a/src/canvas-extensions/node-ratio-canvas-extension.ts
+++ b/src/canvas-extensions/node-ratio-canvas-extension.ts
@@ -2,14 +2,39 @@ import { Canvas, CanvasNode } from 'src/@types/Canvas'
 import CanvasExtension from './canvas-extension'
 import { Menu } from 'obsidian'
 import { AbstractSelectionModal } from 'src/utils/modal-helper'
+import CanvasHelper from 'src/utils/canvas-helper'
+
+const NO_RATIO = 'No ratio enforcement'
+
+interface RatioOption {
+  /** Full name, used in the selection modal and as the tooltip in the popup menu */
+  label: string
+  /** Short name, used on the popup menu button */
+  text: string
+  /** `null` means "no ratio enforcement" */
+  ratio: number | null
+}
+
+const RATIO_OPTIONS: RatioOption[] = [
+  { label: '16:9', text: '16:9', ratio: 16 / 9 },
+  { label: '4:3', text: '4:3', ratio: 4 / 3 },
+  { label: '3:2', text: '3:2', ratio: 3 / 2 },
+  { label: '1:1', text: '1:1', ratio: 1 },
+  { label: NO_RATIO, text: 'None', ratio: null }
+]
 
 export default class NodeRatioCanvasExtension extends CanvasExtension {
   isEnabled() { return true }
-  
+
   init() {
     this.plugin.registerEvent(this.plugin.app.workspace.on(
       'canvas:node-menu',
       (menu: Menu, node: CanvasNode) => this.onNodeMenu(menu, node)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:popup-menu-created',
+      (canvas: Canvas) => this.onPopupMenuCreated(canvas)
     ))
 
     this.plugin.registerEvent(this.plugin.app.workspace.on(
@@ -23,38 +48,87 @@ export default class NodeRatioCanvasExtension extends CanvasExtension {
 
     menu.addItem((item) => {
       item.setTitle('Set Aspect Ratio')
-        .setIcon('aspect-ratio')
+        .setIcon('ratio')
         .onClick(async () => {
-          const NO_RATIO = 'No ratio enforcement'
-          const newRatioString = await new AbstractSelectionModal(this.plugin.app, 'Enter aspect ratio (width:height)', ['16:9', '4:3', '3:2', '1:1', NO_RATIO])
+          const newRatioString = await new AbstractSelectionModal(this.plugin.app, 'Enter aspect ratio (width:height)', RATIO_OPTIONS.map(option => option.label))
             .awaitInput()
 
-          const nodeData = node.getData()
-
-          // Remove the ratio if the user selected "No ratio enforcement"
-          if (newRatioString === NO_RATIO) {
-            node.setData({
-              ...nodeData,
-              ratio: undefined
-            })
-
+          const selectedOption = RATIO_OPTIONS.find(option => option.label === newRatioString)
+          if (selectedOption) {
+            this.setNodeRatio(node, selectedOption.ratio)
             return
           }
 
-          // Otherwise, parse the ratio and set it
+          // Allow custom ratios that aren't in the list
           const [width, height] = newRatioString.split(':').map(Number)
-          if (width && height) {
-            node.setData({
-              ...nodeData,
-              ratio: width / height
-            })
-
-            node.setData({
-              ...node.getData(),
-              width: nodeData.height * (width / height),
-            })
-          }
+          if (width && height) this.setNodeRatio(node, width / height)
         })
+    })
+  }
+
+  private onPopupMenuCreated(canvas: Canvas) {
+    if (!this.plugin.settings.getSetting('aspectRatioControlFeatureEnabled')) return
+
+    // If the canvas is readonly or there are multiple/no nodes selected, return
+    const selectedNodesData = canvas.getSelectionData().nodes
+    if (canvas.readonly || selectedNodesData.length !== 1 || canvas.selection.size > 1) return
+
+    const selectedNode = canvas.nodes.get(selectedNodesData[0].id)
+    if (!selectedNode) return
+
+    const currentRatio = selectedNode.getData().ratio ?? null
+
+    const menuOption = CanvasHelper.createExpandablePopupMenuOption({
+      id: 'set-aspect-ratio',
+      label: 'Set aspect ratio',
+      icon: 'ratio'
+    }, RATIO_OPTIONS.map(option => ({
+      label: option.label,
+      icon: 'ratio',
+      text: option.text,
+      callback: () => {
+        this.setNodeRatio(selectedNode, option.ratio)
+
+        // Close the submenu
+        menuOption.dispatchEvent(new Event('click'))
+      }
+    })))
+
+    // Mark the currently enforced ratio once the submenu gets opened
+    menuOption.addEventListener('click', () => {
+      const submenu = menuOption.parentElement?.querySelector(`#${menuOption.id}-submenu`)
+      if (!submenu) return
+
+      const activeIndex = RATIO_OPTIONS.findIndex(option =>
+        option.ratio === null ? currentRatio === null : Math.abs(option.ratio - (currentRatio ?? 0)) < 0.001
+      )
+      if (activeIndex >= 0) submenu.children[activeIndex]?.classList.add('is-active')
+    })
+
+    CanvasHelper.addPopupMenuOption(canvas, menuOption)
+  }
+
+  private setNodeRatio(node: CanvasNode, ratio: number | null) {
+    const nodeData = node.getData()
+
+    // Remove the ratio if the user selected "No ratio enforcement"
+    if (ratio === null) {
+      node.setData({
+        ...nodeData,
+        ratio: undefined
+      })
+
+      return
+    }
+
+    node.setData({
+      ...nodeData,
+      ratio: ratio
+    })
+
+    node.setData({
+      ...node.getData(),
+      width: nodeData.height * ratio
     })
   }
 

--- a/src/canvas-extensions/portals-canvas-extension.ts
+++ b/src/canvas-extensions/portals-canvas-extension.ts
@@ -23,6 +23,12 @@ export default class PortalsCanvasExtension extends CanvasExtension {
       (canvas: Canvas) => this.onPopupMenu(canvas)
     ))
 
+    // Added by an LLM agent
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-created',
+      (canvas: Canvas, node: CanvasNode) => void this.tryAutoOpenSingleNodePortal(canvas, node)
+    ))
+
     this.plugin.registerEvent(this.plugin.app.workspace.on(
       'advanced-canvas:node-removed',
       (canvas: Canvas, node: CanvasNode) => this.onNodeRemoved(canvas, node)
@@ -243,6 +249,55 @@ export default class PortalsCanvasExtension extends CanvasExtension {
         }
       })
     )
+  }
+
+  // Added by an LLM agent
+  // Automatically opens a newly created file node as a portal if it links to a canvas
+  // file that only contains a single node - saves a manual "Open portal" click for
+  // canvases that are trivial enough to just inline.
+  private async tryAutoOpenSingleNodePortal(canvas: Canvas, node: CanvasNode) {
+    if (!this.plugin.settings.getSetting('autoOpenSingleNodePortals')) return
+
+    const nodeData = node.getData() as CanvasFileNodeData
+    if (nodeData.type !== 'file' || nodeData.portal) return
+
+    // Use the live `.file` property, not `nodeData.file` - for freshly created file nodes
+    // the data isn't populated with the file path yet at this point. `.file` is set first,
+    // but as a bare path string until the node's own async file loading resolves it to a
+    // TFile, so resolve it through the vault ourselves rather than assuming the type.
+    const portalFilePath = typeof node.file === 'string' ? node.file : node.file?.path
+    if (!portalFilePath) return
+
+    const portalFile = this.plugin.app.vault.getAbstractFileByPath(portalFilePath)
+    if (!(portalFile instanceof TFile) || portalFile.extension !== 'canvas') return
+
+    // Fix direct recursion
+    if (portalFile.path === canvas.view.file?.path) return
+
+    const portalFileDataString = await this.plugin.app.vault.cachedRead(portalFile)
+    if (portalFileDataString === '') return
+
+    let portalFileData: CanvasData
+    try {
+      portalFileData = JSON.parse(portalFileDataString) as CanvasData
+    } catch (error) {
+      return
+    }
+    if (!portalFileData?.nodes || portalFileData.nodes.length !== 1) return
+
+    // Re-fetch the node in case it got removed/replaced while awaiting the file read
+    const currentNode = canvas.nodes.get(node.id)
+    if (!currentNode) return
+
+    // The node's own async file loading may not have populated `file` on its data yet -
+    // setPortalOpen()/tryOpenPortal() need it, so make sure it's there before opening
+    const currentNodeData = currentNode.getData() as CanvasFileNodeData
+    if (currentNodeData.portal) return // Someone else already toggled it open in the meantime
+    if (currentNodeData.file !== portalFile.path) {
+      currentNode.setData({ ...currentNodeData, file: portalFile.path })
+    }
+
+    this.setPortalOpen(canvas, currentNode, true)
   }
 
   private setPortalOpen(canvas: Canvas, portalNode: CanvasNode, open: boolean) {

--- a/src/canvas-extensions/presentation-canvas-extension.ts
+++ b/src/canvas-extensions/presentation-canvas-extension.ts
@@ -370,6 +370,18 @@ export default class PresentationCanvasExtension extends CanvasExtension {
     this.presentationUsesFullscreen = false
   }
 
+  // Added by an LLM agent
+  /** Re-focuses the viewport on the slide the presentation is currently on. */
+  zoomToCurrentSlide(canvas: Canvas) {
+    const currentNodeId = this.visitedNodeIds.last()
+    if (!currentNodeId) return
+
+    const currentNode = canvas.nodes.get(currentNodeId)
+    if (!currentNode) return
+
+    void this.animateNodeTransition(canvas, currentNode, currentNode)
+  }
+
   private nextNode(canvas: Canvas) {
     const fromNodeId = this.visitedNodeIds.last()
     if (!fromNodeId) return

--- a/src/canvas-extensions/rotate-node-canvas-extension.ts
+++ b/src/canvas-extensions/rotate-node-canvas-extension.ts
@@ -1,0 +1,638 @@
+// Added by an LLM agent
+import { Menu, Notice } from "obsidian"
+import { BBox, Canvas, CanvasEdge, CanvasNode, Position } from "src/@types/Canvas"
+import { CanvasFileNodeData, Side } from "src/@types/AdvancedJsonCanvas"
+import BBoxHelper from "src/utils/bbox-helper"
+import CanvasHelper from "src/utils/canvas-helper"
+import { AbstractSelectionModal } from "src/utils/modal-helper"
+import CanvasExtension from "./canvas-extension"
+
+/**
+ * Added by an LLM agent.
+ *
+ * Node & content rotation:
+ * - `rotation` (degrees clockwise, normalized to [0, 360)) rotates a node around its own center.
+ *   It is purely visual: x/y/width/height in the data never change, so it is reversible and
+ *   doesn't conflict with the ratio/snap features. Rotating a container (a group or an open
+ *   portal) rigidly rotates all fully contained nodes with it (nested rotated containers
+ *   compose). Open portals act as containers because their nested notes are real nodes fully
+ *   contained in the portal's bbox.
+ * - `contentRotation` (cardinal only: 0/90/180/270) rotates just the inner content via CSS
+ *   (see styles/rotate-node.scss). E.g. a node rotated 90° CW + content rotation of 270°
+ *   (= 90° CCW) makes the text read normally inside the rotated frame.
+ *   `contentRotation` on a container (a group or an open portal) does NOT rotate the container's
+ *   own content - it propagates to every fully contained node instead (their effective content
+ *   rotation is the sum of their own and all containing containers', mod 360).
+ *
+ * Rendering: Obsidian's `CanvasNode.render()` writes the inline style
+ * `transform: translate(xpx, ypx)` on the node element. The canvas patcher already fires
+ * `advanced-canvas:node-rendered` right after - this extension rewrites the inline transform
+ * synchronously in the same frame (no flicker, works at drag speed, no new monkey-patch needed).
+ *
+ * Edges: Obsidian's `CanvasEdge.updatePath()` anchors the path (and the arrow heads) to the
+ * unrotated data bbox. The `advanced-canvas:edge-path-updated` hook re-anchors both ends:
+ * the bezier end/control points, the border stubs and the arrow head transforms get rotated
+ * around each node's composed center by its total rotation angle.
+ *
+ * Known limitations:
+ * - Rubber-band selection & resize handles stay axis-aligned (rotation is a visual layer over
+ *   data space).
+ * - Edges with a pathfinding style (`pathfindingMethod`) are not re-anchored - the edge styles
+ *   extension replaces their whole path after this extension's hook runs.
+ * - While editing a content-rotated text node, the inline editor (iframe) may appear unrotated;
+ *   the rotation shows in reading/preview.
+ */
+
+const CONTENT_ROTATION_OPTIONS: { label: string, value: 0 | 90 | 180 | 270 }[] = [
+  { label: 'None', value: 0 },
+  { label: '90° clockwise', value: 90 },
+  { label: '180°', value: 180 },
+  { label: '90° counter-clockwise', value: 270 }
+]
+
+/** Mirrors Obsidian's internal side -> arrow head rotation map (`q5` in obsidian.asar) */
+const SIDE_ARROW_ANGLES: Record<Side, number> = { top: 180, bottom: 0, left: 90, right: 270 }
+
+interface RotatedContainer {
+  node: CanvasNode
+  rotation: number
+  bbox: BBox
+  center: Position
+}
+
+/** Normalize an angle in degrees to [0, 360) */
+function normalizeAngle(angle: number): number {
+  const normalized = angle % 360
+  return normalized < 0 ? normalized + 360 : normalized
+}
+
+/** Rotate a point around a center by the given angle (degrees clockwise, matching CSS `rotate()` in screen coordinates) */
+function rotatePointAround(point: Position, center: Position, angleDeg: number): Position {
+  if (angleDeg === 0) return point
+
+  const rad = angleDeg * Math.PI / 180
+  const cos = Math.cos(rad)
+  const sin = Math.sin(rad)
+  const dx = point.x - center.x
+  const dy = point.y - center.y
+
+  return {
+    x: center.x + dx * cos - dy * sin,
+    y: center.y + dx * sin + dy * cos
+  }
+}
+
+/** The smallest axis-aligned bbox containing all given points */
+function pointsBBox(points: Position[]): BBox {
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+
+  for (const point of points) {
+    minX = Math.min(minX, point.x)
+    minY = Math.min(minY, point.y)
+    maxX = Math.max(maxX, point.x)
+    maxY = Math.max(maxY, point.y)
+  }
+
+  return { minX, minY, maxX, maxY }
+}
+
+function nodeBBox(node: CanvasNode): BBox {
+  return { minX: node.x, minY: node.y, maxX: node.x + node.width, maxY: node.y + node.height }
+}
+
+export default class RotateNodeCanvasExtension extends CanvasExtension {
+  isEnabled() { return 'nodeRotationFeatureEnabled' as const }
+
+  /** Per-canvas cache: does any node/group have a rotation? Invalidated on data changes. */
+  private rotationPresenceCache = new WeakMap<Canvas, boolean>()
+
+  /** Edges whose path/arrow heads this extension re-anchored (so they get restored when unrotated) */
+  private rotatedEdges = new WeakSet<CanvasEdge>()
+
+  init() {
+    // Recompute the transform right after Obsidian rendered the node (same frame, covers drag/resize)
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-rendered',
+      (canvas: Canvas, node: CanvasNode) => {
+        if (!this.getRotationPresence(canvas)) return
+        this.updateNodeTransform(canvas, node, this.getRotatedContainers(canvas))
+      }
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-changed',
+      (canvas: Canvas) => this.onRotationDataMaybeChanged(canvas)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-removed',
+      (canvas: Canvas) => this.onRotationDataMaybeChanged(canvas)
+    ))
+
+    // Full refresh triggers (all idempotent)
+    for (const event of ['advanced-canvas:data-loaded:after', 'advanced-canvas:canvas-changed', 'advanced-canvas:undo', 'advanced-canvas:redo'] as const) {
+      this.plugin.registerEvent(this.plugin.app.workspace.on(
+        event,
+        (canvas: Canvas) => this.onRotationDataMaybeChanged(canvas)
+      ))
+    }
+
+    // Re-anchor edges to rotated nodes right after Obsidian recalculated the path
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:edge-path-updated',
+      (canvas: Canvas, edge: CanvasEdge) => this.onEdgePathUpdated(canvas, edge)
+    ))
+
+    // Added by an LLM agent:
+    // Obsidian's viewport virtualization (virtualize() in obsidian.asar) culls nodes/edges
+    // whose DATA-space bbox doesn't intersect the viewport bbox (nodeIndex/edgeIndex search).
+    // Rotation here is purely visual (CSS transform), so a rotated node - e.g. inside a rotated
+    // open portal - can be visually on-screen while its data bbox is outside the viewport and
+    // gets detached (it "disappears" when zooming in). Add visually intersecting elements back.
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:intersecting-nodes-requested',
+      (canvas: Canvas, bbox: BBox, nodes: CanvasNode[]) => this.onIntersectingNodesRequested(canvas, bbox, nodes)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:intersecting-edges-requested',
+      (canvas: Canvas, bbox: BBox, edges: CanvasEdge[]) => this.onIntersectingEdgesRequested(canvas, bbox, edges)
+    ))
+
+    // Mirror the effective content rotation into the editing iframe too (node-exposer pattern)
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'advanced-canvas:node-editing-state-changed',
+      (canvas: Canvas, node: CanvasNode, editing: boolean) => {
+        if (!editing) return
+
+        const iframeBody = node.nodeEl.querySelector('iframe')?.contentDocument?.body
+        if (iframeBody) this.applyContentRotationAttribute(iframeBody, this.getEffectiveContentRotation(canvas, node))
+      }
+    ))
+
+    // Context menus
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'canvas:node-menu',
+      (menu: Menu, node: CanvasNode) => this.addRotationMenuItems(node.canvas, [node], menu)
+    ))
+
+    this.plugin.registerEvent(this.plugin.app.workspace.on(
+      'canvas:selection-menu',
+      (menu: Menu, canvas: Canvas) => this.addRotationMenuItems(canvas, this.getSelectedNodes(canvas), menu)
+    ))
+
+    // Commands (hotkeyable, only when a canvas with a node selection is active)
+    this.plugin.addCommand({
+      id: 'rotate-selection-90-clockwise',
+      name: 'Rotate selection 90° clockwise',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && canvas.getSelectionData().nodes.length > 0,
+        (canvas: Canvas) => this.rotateNodesBy(canvas, this.getSelectedNodes(canvas), 90)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'rotate-selection-90-counterclockwise',
+      name: 'Rotate selection 90° counterclockwise',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && canvas.getSelectionData().nodes.length > 0,
+        (canvas: Canvas) => this.rotateNodesBy(canvas, this.getSelectedNodes(canvas), -90)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'rotate-selection-180',
+      name: 'Rotate selection 180°',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && canvas.getSelectionData().nodes.length > 0,
+        (canvas: Canvas) => this.rotateNodesBy(canvas, this.getSelectedNodes(canvas), 180)
+      )
+    })
+
+    this.plugin.addCommand({
+      id: 'reset-selection-rotation',
+      name: 'Reset selection rotation',
+      checkCallback: CanvasHelper.canvasCommand(
+        this.plugin,
+        (canvas: Canvas) => !canvas.readonly && canvas.getSelectionData().nodes.length > 0,
+        (canvas: Canvas) => this.setNodesRotation(canvas, this.getSelectedNodes(canvas), 0)
+      )
+    })
+  }
+
+  /**
+   * Single entry point for every data change that can affect rotations (idempotent).
+   * Updates node transforms, content rotation attributes and edge paths.
+   */
+  private onRotationDataMaybeChanged(canvas: Canvas) {
+    this.rotationPresenceCache.delete(canvas)
+
+    // If rotations exist, a moved/resized/rotated container changes the pivot of all its
+    // members -> refresh all nodes. Otherwise restore every node we previously rewrote
+    // (e.g. the members of a container whose rotation was just removed).
+    if (this.getRotationPresence(canvas)) {
+      this.updateAllNodeTransforms(canvas, this.getRotatedContainers(canvas))
+    } else {
+      for (const node of canvas.nodes.values()) {
+        const vanillaTransform = `translate(${node.x}px, ${node.y}px)` // Obsidian's own format
+        if (node.nodeEl.style.transform !== vanillaTransform) this.updateNodeTransform(canvas, node, [])
+      }
+    }
+
+    this.updateAllContentRotationAttributes(canvas)
+    this.refreshEdges(canvas, this.getRotatedContainers(canvas))
+  }
+
+  private getSelectedNodes(canvas: Canvas): CanvasNode[] {
+    return canvas.getSelectionData().nodes
+      .map(nodeData => canvas.nodes.get(nodeData.id))
+      .filter(node => node !== undefined) as CanvasNode[]
+  }
+
+  private addRotationMenuItems(canvas: Canvas, nodes: CanvasNode[], menu: Menu) {
+    if (canvas.readonly || nodes.length === 0) return
+
+    menu.addSeparator()
+
+    menu.addItem(item => {
+      item.setTitle('Rotate 90° clockwise')
+      item.setIcon('rotate-cw')
+      item.onClick(() => this.rotateNodesBy(canvas, nodes, 90))
+    })
+
+    menu.addItem(item => {
+      item.setTitle('Rotate 90° counterclockwise')
+      item.setIcon('rotate-ccw')
+      item.onClick(() => this.rotateNodesBy(canvas, nodes, -90))
+    })
+
+    menu.addItem(item => {
+      item.setTitle('Rotate 180°')
+      item.setIcon('refresh-cw')
+      item.onClick(() => this.rotateNodesBy(canvas, nodes, 180))
+    })
+
+    menu.addItem(item => {
+      item.setTitle('Set rotation angle…')
+      item.setIcon('compass')
+      item.onClick(async () => {
+        const input = await new AbstractSelectionModal(
+          this.plugin.app,
+          'Enter a rotation angle in degrees (clockwise)',
+          ['0', '45', '90', '135', '180', '225', '270', '315'],
+          true // Allow arbitrary angles
+        ).awaitInput()
+
+        const angle = Number(input)
+        if (isNaN(angle)) {
+          new Notice('Invalid rotation angle')
+          return
+        }
+
+        this.setNodesRotation(canvas, nodes, angle)
+      })
+    })
+
+    if (nodes.some(node => normalizeAngle(node.getData().rotation ?? 0) !== 0)) {
+      menu.addItem(item => {
+        item.setTitle('Reset rotation')
+        item.setIcon('undo-2')
+        item.onClick(() => this.setNodesRotation(canvas, nodes, 0))
+      })
+    }
+
+    menu.addSeparator()
+
+    for (const option of CONTENT_ROTATION_OPTIONS) {
+      menu.addItem(item => {
+        item.setTitle(`Content rotation: ${option.label}`)
+        item.setIcon(option.value === 0 ? 'ban' : 'rotate-cw')
+        item.onClick(() => this.setNodesContentRotation(canvas, nodes, option.value))
+      })
+    }
+
+    menu.addSeparator()
+  }
+
+  private rotateNodesBy(canvas: Canvas, nodes: CanvasNode[], deltaDeg: number) {
+    for (const node of nodes) {
+      const newRotation = normalizeAngle((node.getData().rotation ?? 0) + deltaDeg)
+      node.setData({
+        ...node.getData(),
+        rotation: newRotation === 0 ? undefined : newRotation // Keep the canvas JSON clean
+      })
+    }
+
+    // Single undo step for multi-node operations (node-styles pattern)
+    canvas.pushHistory(canvas.getData())
+  }
+
+  private setNodesRotation(canvas: Canvas, nodes: CanvasNode[], angleDeg: number) {
+    const rotation = normalizeAngle(angleDeg)
+
+    for (const node of nodes) {
+      node.setData({
+        ...node.getData(),
+        rotation: rotation === 0 ? undefined : rotation // Keep the canvas JSON clean
+      })
+    }
+
+    canvas.pushHistory(canvas.getData())
+  }
+
+  private setNodesContentRotation(canvas: Canvas, nodes: CanvasNode[], contentRotation: 0 | 90 | 180 | 270) {
+    for (const node of nodes) {
+      node.setData({
+        ...node.getData(),
+        contentRotation: contentRotation === 0 ? undefined : contentRotation // Keep the canvas JSON clean
+      })
+    }
+
+    canvas.pushHistory(canvas.getData())
+  }
+
+  private getRotationPresence(canvas: Canvas): boolean {
+    const cached = this.rotationPresenceCache.get(canvas)
+    if (cached !== undefined) return cached
+
+    const hasRotation = [...canvas.nodes.values()]
+      .some(node => normalizeAngle(node.getData().rotation ?? 0) !== 0)
+
+    this.rotationPresenceCache.set(canvas, hasRotation)
+    return hasRotation
+  }
+
+  /** All rotated containers (groups and open portals), outermost first (sorted by bbox area descending) */
+  private getRotatedContainers(canvas: Canvas): RotatedContainer[] {
+    return [...canvas.nodes.values()]
+      .filter(node => this.isRotationContainer(node))
+      .map(node => ({ node, rotation: normalizeAngle(node.getData().rotation ?? 0) }))
+      .filter(({ rotation }) => rotation !== 0)
+      .map(({ node, rotation }) => ({
+        node,
+        rotation,
+        bbox: nodeBBox(node),
+        center: { x: node.x + node.width / 2, y: node.y + node.height / 2 }
+      }))
+      .sort((a, b) =>
+        (b.bbox.maxX - b.bbox.minX) * (b.bbox.maxY - b.bbox.minY) -
+        (a.bbox.maxX - a.bbox.minX) * (a.bbox.maxY - a.bbox.minY)
+      )
+  }
+
+  /** An open portal node (its nested notes are real nodes fully contained in the portal's bbox) */
+  private isOpenPortal(node: CanvasNode): boolean {
+    const data = node.getData() as CanvasFileNodeData
+    return data.type === 'file' && data.portal === true && data.isPortalLoaded === true
+  }
+
+  /** Rotation containers: rotating them rigidly rotates every fully contained node with them */
+  private isRotationContainer(node: CanvasNode): boolean {
+    return node.getData().type === 'group' || this.isOpenPortal(node)
+  }
+
+  /**
+   * The composed rigid transform of a node: outermost -> innermost rotated containers (each
+   * around the container's own already-transformed center), then the node's own rotation around
+   * its own (already container-transformed) center. Because the container frame and its members
+   * receive the same rigid transform, members stay inside the rotated container.
+   */
+  private getNodeRotationInfo(canvas: Canvas, node: CanvasNode, rotatedContainers: RotatedContainer[]): { center: Position, angle: number } {
+    const ownRotation = normalizeAngle(node.getData().rotation ?? 0)
+    const bbox = nodeBBox(node)
+    const containingContainers = rotatedContainers.filter(container => container.node !== node && BBoxHelper.insideBBox(bbox, container.bbox, true))
+
+    let center: Position = { x: node.x + node.width / 2, y: node.y + node.height / 2 }
+    let totalAngle = ownRotation
+
+    const appliedSteps: { center: Position, angle: number }[] = []
+    for (const container of containingContainers) {
+      let containerCenter = container.center
+      for (const step of appliedSteps) containerCenter = rotatePointAround(containerCenter, step.center, step.angle)
+      appliedSteps.push({ center: containerCenter, angle: container.rotation })
+
+      center = rotatePointAround(center, containerCenter, container.rotation)
+      totalAngle += container.rotation
+    }
+
+    return { center, angle: normalizeAngle(totalAngle) }
+  }
+
+  private updateAllNodeTransforms(canvas: Canvas, rotatedContainers: RotatedContainer[]) {
+    for (const node of canvas.nodes.values()) this.updateNodeTransform(canvas, node, rotatedContainers)
+  }
+
+  private updateNodeTransform(canvas: Canvas, node: CanvasNode, rotatedContainers: RotatedContainer[]) {
+    const { center, angle } = this.getNodeRotationInfo(canvas, node, rotatedContainers)
+
+    if (this.isVisuallyUnchanged(node, { center, angle })) {
+      // Unrotated node: restore Obsidian's vanilla transform if we previously rewrote it,
+      // so untouched nodes stay byte-identical to vanilla
+      if (node.nodeEl.style.transform.includes('rotate('))
+        node.nodeEl.style.transform = `translate(${node.x}px, ${node.y}px)`
+
+      return
+    }
+
+    const tx = center.x - node.width / 2
+    const ty = center.y - node.height / 2
+    const transform = angle === 0
+      ? `translate(${tx}px, ${ty}px)`
+      : `translate(${tx}px, ${ty}px) rotate(${angle}deg)`
+
+    if (node.nodeEl.style.transform !== transform) node.nodeEl.style.transform = transform
+  }
+
+  // Added by an LLM agent (all methods below in this section):
+  // Viewport virtualization support - keep rotated nodes/edges attached while they are
+  // visually inside the viewport, even though their data-space bbox is not.
+
+  /** Whether the composed rigid transform leaves the node exactly where its data bbox is */
+  private isVisuallyUnchanged(node: CanvasNode, info: { center: Position, angle: number }): boolean {
+    return info.angle === 0 &&
+      info.center.x === node.x + node.width / 2 &&
+      info.center.y === node.y + node.height / 2
+  }
+
+  /** The axis-aligned bbox of a node's visual rectangle (its rect rotated around its composed center) */
+  private getVisualNodeBBox(node: CanvasNode, info: { center: Position, angle: number }): BBox {
+    const halfWidth = node.width / 2
+    const halfHeight = node.height / 2
+
+    return pointsBBox([
+      { x: info.center.x - halfWidth, y: info.center.y - halfHeight },
+      { x: info.center.x + halfWidth, y: info.center.y - halfHeight },
+      { x: info.center.x + halfWidth, y: info.center.y + halfHeight },
+      { x: info.center.x - halfWidth, y: info.center.y + halfHeight }
+    ].map(corner => rotatePointAround(corner, info.center, info.angle)))
+  }
+
+  private onIntersectingNodesRequested(canvas: Canvas, bbox: BBox, nodes: CanvasNode[]) {
+    if (!this.getRotationPresence(canvas)) return
+
+    const rotatedContainers = this.getRotatedContainers(canvas)
+    const included = new Set(nodes)
+
+    for (const node of canvas.nodes.values()) {
+      if (included.has(node)) continue
+
+      const info = this.getNodeRotationInfo(canvas, node, rotatedContainers)
+      if (this.isVisuallyUnchanged(node, info)) continue
+
+      if (BBoxHelper.isColliding(this.getVisualNodeBBox(node, info), bbox)) nodes.push(node)
+    }
+  }
+
+  private onIntersectingEdgesRequested(canvas: Canvas, bbox: BBox, edges: CanvasEdge[]) {
+    if (!this.getRotationPresence(canvas)) return
+
+    const rotatedContainers = this.getRotatedContainers(canvas)
+    const included = new Set(edges)
+
+    for (const edge of canvas.edges.values()) {
+      if (included.has(edge)) continue
+
+      const visualBBox = this.getVisualEdgeBBox(canvas, edge, rotatedContainers)
+      if (visualBBox && BBoxHelper.isColliding(visualBBox, bbox)) edges.push(edge)
+    }
+  }
+
+  /**
+   * The axis-aligned bbox of an edge's visual path. If this extension re-anchored the edge,
+   * its bezier points are already in visual space and the curve is contained in the convex
+   * hull of its control points. Otherwise fall back to the combined visual bbox of both
+   * endpoint nodes. Returns null if neither endpoint is rotated.
+   */
+  private getVisualEdgeBBox(canvas: Canvas, edge: CanvasEdge, rotatedContainers: RotatedContainer[]): BBox | null {
+    const fromInfo = this.getNodeRotationInfo(canvas, edge.from.node, rotatedContainers)
+    const toInfo = this.getNodeRotationInfo(canvas, edge.to.node, rotatedContainers)
+    if (this.isVisuallyUnchanged(edge.from.node, fromInfo) && this.isVisuallyUnchanged(edge.to.node, toInfo)) return null
+
+    if (this.rotatedEdges.has(edge) && edge.bezier)
+      return pointsBBox([edge.bezier.from, edge.bezier.cp1, edge.bezier.cp2, edge.bezier.to])
+
+    return BBoxHelper.combineBBoxes([
+      this.getVisualNodeBBox(edge.from.node, fromInfo),
+      this.getVisualNodeBBox(edge.to.node, toInfo)
+    ])
+  }
+
+  /** Groups and open portals propagate their `contentRotation` to their content instead of rotating their own */
+  private isContentRotationContainer(node: CanvasNode): boolean {
+    return node.getData().type === 'group' || this.isOpenPortal(node)
+  }
+
+  /** The content rotation that applies to a node's own content: own + all containing containers' (cardinal stays cardinal) */
+  private getEffectiveContentRotation(canvas: Canvas, node: CanvasNode): number {
+    if (this.isContentRotationContainer(node)) return 0
+
+    const bbox = nodeBBox(node)
+    let total = node.getData().contentRotation ?? 0
+
+    for (const other of canvas.nodes.values()) {
+      if (other === node || !this.isContentRotationContainer(other)) continue
+
+      const containerRotation = other.getData().contentRotation ?? 0
+      if (containerRotation === 0) continue
+      if (BBoxHelper.insideBBox(bbox, nodeBBox(other), true)) total += containerRotation
+    }
+
+    return normalizeAngle(total)
+  }
+
+  private applyContentRotationAttribute(element: HTMLElement, effectiveRotation: number) {
+    if (effectiveRotation === 0) {
+      if (element.dataset.contentRotation !== undefined) delete element.dataset.contentRotation
+    } else if (element.dataset.contentRotation !== String(effectiveRotation)) {
+      element.dataset.contentRotation = String(effectiveRotation)
+    }
+  }
+
+  private updateAllContentRotationAttributes(canvas: Canvas) {
+    for (const node of canvas.nodes.values())
+      this.applyContentRotationAttribute(node.nodeEl, this.getEffectiveContentRotation(canvas, node))
+  }
+
+  /** Re-runs `updatePath` (which re-fires `edge-path-updated`) for every edge that is or was rotated */
+  private refreshEdges(canvas: Canvas, rotatedContainers: RotatedContainer[]) {
+    for (const edge of canvas.edges.values()) {
+      if (!edge.initialized) continue
+
+      const fromAngle = this.getNodeRotationInfo(canvas, edge.from.node, rotatedContainers).angle
+      const toAngle = this.getNodeRotationInfo(canvas, edge.to.node, rotatedContainers).angle
+      if (fromAngle !== 0 || toAngle !== 0 || this.rotatedEdges.has(edge)) edge.updatePath()
+    }
+  }
+
+  /**
+   * Re-anchors an edge Obsidian just recalculated: maps the bezier end/control points, the
+   * border stubs and the arrow head positions from data space to on-screen space using each
+   * connected node's composed rigid transform. Mirrors Obsidian's own `updatePath` geometry
+   * (see obsidian.asar: `V5`/`z5`/`q5`).
+   */
+  private onEdgePathUpdated(canvas: Canvas, edge: CanvasEdge) {
+    // The edge styles extension replaces the whole path of pathfinding edges after this hook
+    if (edge.getData().styleAttributes?.pathfindingMethod) return
+    if (!edge.bezier || !edge.path?.display) return
+
+    const rotatedContainers = this.getRotatedContainers(canvas)
+    const fromInfo = this.getNodeRotationInfo(canvas, edge.from.node, rotatedContainers)
+    const toInfo = this.getNodeRotationInfo(canvas, edge.to.node, rotatedContainers)
+
+    if (fromInfo.angle === 0 && toInfo.angle === 0) {
+      this.rotatedEdges.delete(edge)
+      return
+    }
+
+    const from = this.applyNodeRotation(edge.bezier.from, edge.from.node, fromInfo)
+    const cp1 = this.applyNodeRotation(edge.bezier.cp1, edge.from.node, fromInfo)
+    const to = this.applyNodeRotation(edge.bezier.to, edge.to.node, toInfo)
+    const cp2 = this.applyNodeRotation(edge.bezier.cp2, edge.to.node, toInfo)
+    const curve = `M${from.x},${from.y} C${cp1.x},${cp1.y} ${cp2.x},${cp2.y} ${to.x},${to.y}`
+
+    Object.assign(edge.bezier, { from, cp1, to, cp2, path: curve })
+
+    // Arrow heads sit on the (now rotated) node border, pointing along the rotated side normal;
+    // an end without an arrow head gets a stub out to the border, same as Obsidian's own path
+    let path = curve
+    const fromBorder = this.applyNodeRotation(BBoxHelper.getCenterOfBBoxSide(edge.from.node.getBBox(), edge.from.side), edge.from.node, fromInfo)
+    const toBorder = this.applyNodeRotation(BBoxHelper.getCenterOfBBoxSide(edge.to.node.getBBox(), edge.to.side), edge.to.node, toInfo)
+
+    if (edge.fromLineEnd) {
+      const arrowAngle = normalizeAngle(SIDE_ARROW_ANGLES[edge.from.side] + fromInfo.angle)
+      edge.fromLineEnd.el.style.transform = `translate(${fromBorder.x}px, ${fromBorder.y}px) rotate(${arrowAngle}deg)`
+    } else {
+      path = `M${fromBorder.x} ${fromBorder.y} L${from.x} ${from.y} ${path}`
+    }
+
+    if (edge.toLineEnd) {
+      const arrowAngle = normalizeAngle(SIDE_ARROW_ANGLES[edge.to.side] + toInfo.angle)
+      edge.toLineEnd.el.style.transform = `translate(${toBorder.x}px, ${toBorder.y}px) rotate(${arrowAngle}deg)`
+    } else {
+      path = `${path} M${to.x} ${to.y} L${toBorder.x} ${toBorder.y}`
+    }
+
+    edge.path.interaction.setAttribute('d', path)
+    edge.path.display.setAttribute('d', path)
+
+    this.rotatedEdges.add(edge)
+  }
+
+  /**
+   * Maps a point from a node's data space to its on-screen position: rotate around the node's
+   * DATA center by the composed angle, then shift by how far the composed center moved.
+   * (Rotating around the composed center directly is wrong for nodes inside rotated containers.)
+   */
+  private applyNodeRotation(point: Position, node: CanvasNode, info: { center: Position, angle: number }): Position {
+    const dataCenter = { x: node.x + node.width / 2, y: node.y + node.height / 2 }
+    const rotated = rotatePointAround(point, dataCenter, info.angle)
+
+    return {
+      x: rotated.x + info.center.x - dataCenter.x,
+      y: rotated.y + info.center.y - dataCenter.y
+    }
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import FileManagerPatcher from './patchers/file-manager-patcher'
 import PropertiesPatcher from './patchers/properties-patcher'
 import SearchPatcher from './patchers/search-patcher'
 import SearchCommandPatcher from './patchers/search-command-patcher'
+import DotMdFileSearchPatcher from './patchers/dot-md-file-search-patcher' // Added by an LLM agent
 
 // Canvas Extensions
 import CanvasExtension from './canvas-extensions/canvas-extension'
@@ -55,6 +56,7 @@ import EdgeLabelMarkdownCanvasExtension from './canvas-extensions/edge-label-mar
 import EdgeArrowBaseCanvasExtension from './canvas-extensions/edge-arrow-base-canvas-extension' // Added by an LLM agent
 import CopyNodeReferenceCanvasExtension from './canvas-extensions/copy-node-reference-canvas-extension'
 import ReadingModeFixCanvasExtension from './canvas-extensions/reading-mode-fix-canvas-extension'
+import RotateNodeCanvasExtension from './canvas-extensions/rotate-node-canvas-extension' // Added by an LLM agent
 
 // Advanced Styles
 import NodeStylesExtension from './canvas-extensions/advanced-styles/node-styles'
@@ -72,6 +74,7 @@ const PATCHERS = [
   // Core canvas patchers
   CanvasPatcher,
   SearchCommandPatcher,
+  DotMdFileSearchPatcher, // Added by an LLM agent
 
   // Core metadata patchers
   MetadataCachePatcher,
@@ -132,7 +135,8 @@ const CANVAS_EXTENSIONS: typeof CanvasExtension[] = [
   CanvasFilterCanvasExtension, // Added by an LLM agent
   EncapsulateCanvasExtension,
   EdgeSelectionCanvasExtension,
-  CopyNodeReferenceCanvasExtension
+  CopyNodeReferenceCanvasExtension,
+  RotateNodeCanvasExtension // Added by an LLM agent
 ]
 
 export default class AdvancedCanvasPlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,9 @@ import MetadataCanvasExtension from './canvas-extensions/metadata-canvas-extensi
 import NodeRatioCanvasExtension from './canvas-extensions/node-ratio-canvas-extension'
 import VariableBreakpointCanvasExtension from './canvas-extensions/variable-breakpoint-canvas-extension'
 import GroupCanvasExtension from './canvas-extensions/group-canvas-extension'
+import GroupLabelWrapCanvasExtension from './canvas-extensions/group-label-wrap-canvas-extension' // Added by an LLM agent
+import GroupLabelVisibilityCanvasExtension from './canvas-extensions/group-label-visibility-canvas-extension' // Added by an LLM agent
+import DefaultStyleSizesCanvasExtension from './canvas-extensions/default-style-sizes-canvas-extension' // Added by an LLM agent
 import NodeTemplatesCanvasExtension from './canvas-extensions/node-templates-canvas-extension'
 import PresentationCanvasExtension from './canvas-extensions/presentation-canvas-extension'
 import ZOrderingCanvasExtension from './canvas-extensions/z-ordering-canvas-extension'
@@ -41,12 +44,15 @@ import BetterDefaultSettingsCanvasExtension from './canvas-extensions/better-def
 import ColorPaletteCanvasExtension from './canvas-extensions/color-palette-canvas-extension'
 import CollapsibleGroupsCanvasExtension from './canvas-extensions/collapsible-groups-canvas-extension'
 import FocusModeCanvasExtension from './canvas-extensions/focus-mode-canvas-extension'
+import CanvasFilterCanvasExtension from './canvas-extensions/canvas-filter-canvas-extension' // Added by an LLM agent
 import AutoFileNodeEdgesCanvasExtension from './canvas-extensions/auto-file-node-edges-canvas-extension'
 import FlipEdgeCanvasExtension from './canvas-extensions/flip-edge-canvas-extension'
 import EdgeSelectionCanvasExtension from './canvas-extensions/edge-selection-canvas-extension'
 import ExportCanvasExtension from './canvas-extensions/export-canvas-extension'
 import FloatingEdgeCanvasExtension from './canvas-extensions/floating-edge-canvas-extension'
 import EdgeHighlightCanvasExtension from './canvas-extensions/edge-highlight-canvas-extension'
+import EdgeLabelMarkdownCanvasExtension from './canvas-extensions/edge-label-markdown-canvas-extension' // Added by an LLM agent
+import EdgeArrowBaseCanvasExtension from './canvas-extensions/edge-arrow-base-canvas-extension' // Added by an LLM agent
 import CopyNodeReferenceCanvasExtension from './canvas-extensions/copy-node-reference-canvas-extension'
 import ReadingModeFixCanvasExtension from './canvas-extensions/reading-mode-fix-canvas-extension'
 
@@ -109,14 +115,21 @@ const CANVAS_EXTENSIONS: typeof CanvasExtension[] = [
   BetterReadonlyCanvasExtension,
   ReadingModeFixCanvasExtension,
   GroupCanvasExtension,
+  GroupLabelWrapCanvasExtension, // Added by an LLM agent
+  GroupLabelVisibilityCanvasExtension, // Added by an LLM agent
+  DefaultStyleSizesCanvasExtension, // Added by an LLM agent
   NodeTemplatesCanvasExtension,
   VariableBreakpointCanvasExtension,
   EdgeHighlightCanvasExtension,
+  EdgeLabelMarkdownCanvasExtension, // Added by an LLM agent
+  // Has to come after EdgeStylesExtension - it measures the final path of pathfinding edges
+  EdgeArrowBaseCanvasExtension, // Added by an LLM agent
   AutoFileNodeEdgesCanvasExtension,
   FlipEdgeCanvasExtension,
   ZOrderingCanvasExtension,
   ExportCanvasExtension,
   FocusModeCanvasExtension,
+  CanvasFilterCanvasExtension, // Added by an LLM agent
   EncapsulateCanvasExtension,
   EdgeSelectionCanvasExtension,
   CopyNodeReferenceCanvasExtension

--- a/src/patchers/canvas-patcher.ts
+++ b/src/patchers/canvas-patcher.ts
@@ -159,6 +159,18 @@ export default class CanvasPatcher extends Patcher {
         that.plugin.app.workspace.trigger('advanced-canvas:containing-nodes-requested', this, bbox, result)
         return result
       }),
+      // Added by an LLM agent
+      getIntersectingNodes: Patcher.OverrideExisting(next => function (bbox: BBox): CanvasNode[] {
+        const result = next.call(this, bbox)
+        that.plugin.app.workspace.trigger('advanced-canvas:intersecting-nodes-requested', this, bbox, result)
+        return result
+      }),
+      // Added by an LLM agent
+      getIntersectingEdges: Patcher.OverrideExisting(next => function (bbox: BBox): CanvasEdge[] {
+        const result = next.call(this, bbox)
+        that.plugin.app.workspace.trigger('advanced-canvas:intersecting-edges-requested', this, bbox, result)
+        return result
+      }),
       updateSelection: Patcher.OverrideExisting(next => function (update: () => void): void {
         const oldSelection = new Set(this.selection)
         const result = next.call(this, update)
@@ -310,6 +322,9 @@ export default class CanvasPatcher extends Patcher {
       })
     })
 
+    // Added by an LLM agent: Patch the native grid spacing getter to make the grid size configurable
+    this.patchGridSpacing(view)
+
     // Patch canvas popup menu
     Patcher.patchPrototype<CanvasPopupMenu>(this.plugin, view.canvas.menu, {
       render: Patcher.OverrideExisting(next => function (...args: any): void {
@@ -339,6 +354,33 @@ export default class CanvasPatcher extends Patcher {
 
       that.plugin.app.workspace.trigger('advanced-canvas:node-text-content-changed', node.canvas, node, update)
     })])
+  }
+
+  // Added by an LLM agent: Override the native `gridSpacing` getter so the snap-to-grid size
+  // (drag snapping, resize snapping, arrow-key nudging and the background grid) follows the `gridSize` setting.
+  // Obsidian defines it as a zoom-dependent accessor on the Canvas prototype (tiers of 20/40/80/160).
+  private patchGridSpacing(view: CanvasView) {
+    const canvasPrototype = (view.canvas.constructor as any).prototype
+    const originalDescriptor = Object.getOwnPropertyDescriptor(canvasPrototype, 'gridSpacing')
+    if (!originalDescriptor?.get) {
+      console.warn('Advanced Canvas: Failed to patch gridSpacing - native getter not found')
+      return
+    }
+
+    const that = this // eslint-disable-line @typescript-eslint/no-this-alias -- For patcher
+    Object.defineProperty(canvasPrototype, 'gridSpacing', {
+      get: function (this: Canvas): number {
+        const gridSize = that.plugin.settings.getSetting('gridSize')
+        const zoom = this.zoom
+
+        // Mirror Obsidian's zoom-dependent tiers as multiples of the configured base grid size
+        return zoom < -3.3 ? 8 * gridSize : zoom < -2.16 ? 4 * gridSize : zoom < -0.91 ? 2 * gridSize : gridSize
+      },
+      enumerable: false,
+      configurable: true
+    })
+
+    this.plugin.register(() => Object.defineProperty(canvasPrototype, 'gridSpacing', originalDescriptor))
   }
 
   private patchNode(node: CanvasNode) {

--- a/src/patchers/canvas-patcher.ts
+++ b/src/patchers/canvas-patcher.ts
@@ -485,6 +485,11 @@ export default class CanvasPatcher extends Patcher {
 
         return result
       }),
+      updatePath: Patcher.OverrideExisting(next => function (...args: any): void {
+        const result = next.call(this, ...args)
+        that.plugin.app.workspace.trigger('advanced-canvas:edge-path-updated', this.canvas, this)
+        return result
+      }),
       getCenter: Patcher.OverrideExisting(next => function (...args: any): Position {
         const result = next.call(this, ...args)
         that.plugin.app.workspace.trigger('advanced-canvas:edge-center-requested', this.canvas, this, result)

--- a/src/patchers/dot-md-file-search-patcher.ts
+++ b/src/patchers/dot-md-file-search-patcher.ts
@@ -1,0 +1,151 @@
+// Added by an LLM agent
+import { Modal, Notice, SearchResult, prepareFuzzySearch, renderMatches } from "obsidian"
+import { Canvas } from "src/@types/Canvas"
+import Patcher from "./patcher"
+
+// A file named exactly ".md" is a hidden dotfile. Obsidian's vault layer never indexes
+// dotfiles, so they are missing from vault.getFiles() — and therefore from the canvas
+// "Add note from vault" search modal. The adapter still lists them, so this patcher
+// discovers them via app.vault.adapter and injects them into that modal's suggestions.
+
+// Duck-typed shape of Obsidian's private canvas file-suggest modal
+interface CanvasFileSuggestModal extends Modal {
+  canvas: Canvas
+  shouldShowMarkdown: boolean
+  inputEl?: HTMLInputElement
+  handleChoose: (file: unknown) => void
+  getSuggestions: (query: string) => FileSuggestionItem[]
+  renderSuggestion: (item: FileSuggestionItem, el: HTMLElement) => void
+  onChooseSuggestion: (item: FileSuggestionItem | null, evt: unknown) => void
+  acDotMdPatched?: boolean
+}
+
+interface FileSuggestionItem {
+  type: string
+  file: unknown
+  match: SearchResult | null
+  acDotMdPath?: string
+}
+
+interface DotMdFileEntry {
+  path: string
+  file: unknown // TFile duck-type — the vault has no real TFile for dotfiles
+}
+
+export default class DotMdFileSearchPatcher extends Patcher {
+  private dotMdFiles: DotMdFileEntry[] = []
+
+  protected async patch() {
+    if (!this.plugin.settings.getSetting('dotMdFileSearchEnabled')) return
+
+    const that = this // eslint-disable-line @typescript-eslint/no-this-alias -- For patcher
+    Patcher.patch(this.plugin, Modal.prototype, {
+      open: next => function (this: Modal, ...args: unknown[]): void {
+        that.onModalOpen(this as CanvasFileSuggestModal)
+        next.call(this, ...args)
+      }
+    })
+
+    // Warm the cache on startup so the files are found on the first modal open
+    this.plugin.app.workspace.onLayoutReady(() => void this.refreshDotMdFiles())
+  }
+
+  private onModalOpen(modal: CanvasFileSuggestModal) {
+    // Only patch the canvas "Add note from vault" file-suggest modal
+    // (duck-typed: it is the only suggest modal carrying a canvas reference)
+    if (modal.acDotMdPatched) return
+    if (!modal.canvas || typeof modal.canvas.createFileNode !== 'function') return
+    if (modal.shouldShowMarkdown !== true) return
+    if (typeof modal.getSuggestions !== 'function' || typeof modal.handleChoose !== 'function') return
+    modal.acDotMdPatched = true
+
+    void this.refreshDotMdFiles(modal)
+
+    const that = this // eslint-disable-line @typescript-eslint/no-this-alias -- For patcher
+    Patcher.patch(this.plugin, modal, {
+      getSuggestions: next => function (this: CanvasFileSuggestModal, query: string) {
+        const suggestions = next.call(this, query) as FileSuggestionItem[]
+        // Prepend so the modal's result limit can't cut them off
+        return [...that.getDotMdSuggestions(query), ...suggestions]
+      },
+      renderSuggestion: next => function (this: CanvasFileSuggestModal, item: FileSuggestionItem, el: HTMLElement): void {
+        if (!item?.acDotMdPath) { next.call(this, item, el); return }
+
+        el.addClass('mod-complex')
+        const contentEl = el.createDiv('suggestion-content')
+        const titleEl = contentEl.createDiv('suggestion-title')
+        renderMatches(titleEl, item.acDotMdPath, item.match?.matches ?? null)
+        contentEl.createDiv({ cls: 'suggestion-note', text: 'Hidden dotfile (not indexed by Obsidian)' })
+        el.createDiv('suggestion-aux').createSpan({ cls: 'suggestion-flair' })
+      },
+      onChooseSuggestion: next => function (this: CanvasFileSuggestModal, item: FileSuggestionItem | null, evt: unknown): void {
+        if (!item?.acDotMdPath) { next.call(this, item, evt); return }
+
+        try { this.handleChoose(item.file) }
+        catch (e) {
+          console.error('Advanced Canvas: Failed to add ".md" file node to the canvas.', e)
+          new Notice('Advanced Canvas: Failed to add the ".md" file to the canvas.')
+        }
+      }
+    })
+  }
+
+  private getDotMdSuggestions(query: string): FileSuggestionItem[] {
+    const trimmed = query.trim()
+    if (!trimmed) return this.dotMdFiles.map(entry => this.toSuggestion(entry, null))
+
+    const search = prepareFuzzySearch(trimmed)
+    const suggestions: FileSuggestionItem[] = []
+    for (const entry of this.dotMdFiles) {
+      const match = search(entry.path)
+      if (match) suggestions.push(this.toSuggestion(entry, match))
+    }
+
+    return suggestions
+  }
+
+  private toSuggestion(entry: DotMdFileEntry, match: SearchResult | null): FileSuggestionItem {
+    return { type: 'file', file: entry.file, match: match, acDotMdPath: entry.path }
+  }
+
+  private async refreshDotMdFiles(modal?: CanvasFileSuggestModal) {
+    const entries: DotMdFileEntry[] = []
+
+    const walk = async (folder: string) => {
+      let listed
+      try { listed = await this.plugin.app.vault.adapter.list(folder) }
+      catch { return }
+
+      for (const path of listed.files) {
+        if (path.split('/').pop() === '.md')
+          entries.push({ path: path, file: this.createFakeTFile(path) })
+      }
+
+      // Skip hidden folders (.obsidian, .git, ...) — their content is hidden too
+      for (const subFolder of listed.folders) {
+        if (!subFolder.split('/').pop()?.startsWith('.')) await walk(subFolder)
+      }
+    }
+
+    await walk('/')
+    this.dotMdFiles = entries
+
+    // The walk is async, so the suggestions shown for the current query may be
+    // stale — re-run the search if the modal is still open
+    if (modal?.inputEl && modal.modalEl.isConnected)
+      modal.inputEl.dispatchEvent(new Event('input'))
+  }
+
+  private createFakeTFile(path: string) {
+    return {
+      path: path,
+      name: '.md',
+      basename: '',
+      extension: 'md',
+      stat: { ctime: 0, mtime: 0, size: 0 },
+      vault: this.plugin.app.vault,
+      parent: null,
+      getShortName: () => '.md'
+    }
+  }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ const KOFI_BADGE_URI = 'data:image/webp;base64,UklGRrosAABXRUJQVlA4TK4sAAAv1wNDE
 export interface AdvancedCanvasPluginSettingsValues {
   nodeTypeOnDoubleClick: keyof typeof SETTINGS.general.children.nodeTypeOnDoubleClick.options
   alignNewNodesToGrid: boolean
+  gridSize: number // Added by an LLM agent
   defaultTextNodeDimensions: [number, number]
   defaultFileNodeDimensions: [number, number]
   minNodeSize: number
@@ -23,11 +24,14 @@ export interface AdvancedCanvasPluginSettingsValues {
   disableFontSizeRelativeToZoom: boolean
   wrapGroupLabels: boolean // Added by an LLM agent
   hideGroupLabels: boolean // Added by an LLM agent
+  boxedNodeLabels: boolean // Added by an LLM agent
   defaultGroupLabelSize: keyof typeof SETTINGS.general.children.defaultGroupLabelSize.options // Added by an LLM agent
   defaultGroupOpacity: keyof typeof SETTINGS.general.children.defaultGroupOpacity.options // Added by an LLM agent
   defaultEdgeWidth: keyof typeof SETTINGS.general.children.defaultEdgeWidth.options // Added by an LLM agent
   defaultArrowSize: keyof typeof SETTINGS.general.children.defaultArrowSize.options // Added by an LLM agent
+  cardNodePadding: [number, number] // Added by an LLM agent - [horizontal, vertical] in px
   connectEdgesToArrowBase: boolean // Added by an LLM agent
+  defaultNodeBorder: keyof typeof SETTINGS.general.children.defaultNodeBorder.options // Added by an LLM agent
 
   canvasMetadataCompatibilityEnabled: boolean
   enableSingleNodeLinks: boolean
@@ -59,12 +63,15 @@ export interface AdvancedCanvasPluginSettingsValues {
 
   aspectRatioControlFeatureEnabled: boolean
 
+  nodeRotationFeatureEnabled: boolean // Added by an LLM agent
+
   commandsFeatureEnabled: boolean
   zoomToClonedNode: boolean
   cloneNodeMargin: number
   expandNodeStepSize: number
 
   nativeFileSearchEnabled: boolean
+  dotMdFileSearchEnabled: boolean // Added by an LLM agent
 
   floatingEdgeFeatureEnabled: boolean
   allowFloatingEdgeCreation: boolean
@@ -111,6 +118,7 @@ export interface AdvancedCanvasPluginSettingsValues {
 
   portalsFeatureEnabled: boolean
   showEdgesIntoDisabledPortals: boolean
+  autoOpenSingleNodePortals: boolean // Added by an LLM agent
 
   autoFileNodeEdgesFeatureEnabled: boolean
   autoFileNodeEdgesFrontmatterKey: string
@@ -130,6 +138,7 @@ export interface AdvancedCanvasPluginSettingsValues {
 export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
   nodeTypeOnDoubleClick: 'text',
   alignNewNodesToGrid: true,
+  gridSize: 20, // Added by an LLM agent
   defaultTextNodeDimensions: [260, 60],
   defaultFileNodeDimensions: [400, 400],
   minNodeSize: 60,
@@ -137,11 +146,14 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
   disableFontSizeRelativeToZoom: false,
   wrapGroupLabels: true, // Added by an LLM agent
   hideGroupLabels: false, // Added by an LLM agent
+  boxedNodeLabels: true, // Added by an LLM agent
   defaultGroupLabelSize: '1', // Added by an LLM agent
   defaultGroupOpacity: 'default', // Added by an LLM agent
   defaultEdgeWidth: '1', // Added by an LLM agent
   defaultArrowSize: '1', // Added by an LLM agent
+  cardNodePadding: [16, 0], // Added by an LLM agent - matches Obsidian's own default padding
   connectEdgesToArrowBase: false, // Added by an LLM agent
+  defaultNodeBorder: 'default', // Added by an LLM agent
 
   canvasMetadataCompatibilityEnabled: true,
   enableSingleNodeLinks: true,
@@ -173,12 +185,15 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   aspectRatioControlFeatureEnabled: false,
 
+  nodeRotationFeatureEnabled: false, // Added by an LLM agent
+
   commandsFeatureEnabled: true,
   zoomToClonedNode: true,
   cloneNodeMargin: 20,
   expandNodeStepSize: 20,
 
   nativeFileSearchEnabled: true,
+  dotMdFileSearchEnabled: true, // Added by an LLM agent
 
   floatingEdgeFeatureEnabled: true,
   allowFloatingEdgeCreation: false,
@@ -225,6 +240,7 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   portalsFeatureEnabled: true,
   showEdgesIntoDisabledPortals: true,
+  autoOpenSingleNodePortals: true, // Added by an LLM agent
 
   autoFileNodeEdgesFeatureEnabled: false,
   autoFileNodeEdgesFrontmatterKey: 'canvas-edges',
@@ -260,6 +276,12 @@ export const SETTINGS = {
         label: 'Always align new nodes to grid',
         description: 'When enabled, new nodes will be aligned to the grid.',
         type: 'boolean'
+      },
+      gridSize: { // Added by an LLM agent
+        label: 'Grid size',
+        description: 'The size of the grid that nodes snap to when "Snap to grid" is enabled. Also affects the background grid, arrow-key nudging and grid-aligned features. Obsidian\'s default is 20.',
+        type: 'number',
+        parse: (value: string) => Math.max(1, parseInt(value) || 20)
       },
       defaultTextNodeDimensions: {
         label: 'Default text node dimensions',
@@ -308,6 +330,11 @@ export const SETTINGS = {
         description: 'When enabled, group labels are hidden. Can be toggled with the "Toggle group label visibility" command.',
         type: 'boolean'
       },
+      boxedNodeLabels: { // Added by an LLM agent
+        label: 'Boxed node labels',
+        description: 'When enabled, file/text/link node labels get the same coloured box styling as group labels, instead of plain text.',
+        type: 'boolean'
+      },
       defaultGroupLabelSize: { // Added by an LLM agent
         label: 'Default group label size',
         description: 'The label size used by groups that don\'t have a label size of their own set in the node popup.',
@@ -337,10 +364,10 @@ export const SETTINGS = {
         description: 'The width used by edges that don\'t have an edge width of their own set in the edge popup.',
         type: 'dropdown',
         options: {
-          '0.5': 'Thin (0.5x)',
           '1': 'Default (1x)',
-          '2': 'Thick (2x)',
-          '3': 'Extra Thick (3x)'
+          '2': 'Thin (2x)',
+          '4': 'Thick (4x)',
+          '8': 'Extra Thick (8x)'
         }
       } as DropdownSetting,
       defaultArrowSize: { // Added by an LLM agent
@@ -348,17 +375,38 @@ export const SETTINGS = {
         description: 'The arrow size used by edges that don\'t have an arrow size of their own set in the edge popup.',
         type: 'dropdown',
         options: {
-          '0.5': 'Small (0.5x)',
           '1': 'Default (1x)',
-          '1.5': 'Large (1.5x)',
-          '2': 'Extra Large (2x)'
+		  '2': 'Small (2x)',
+          '3': 'Large (3x)',
+          '4': 'Extra Large (4x)'
         }
       } as DropdownSetting,
+      cardNodePadding: { // Added by an LLM agent
+        label: 'Card node padding (horizontal, vertical)',
+        description: 'The inner padding of a card\'s (text/file node) content, in pixels. Obsidian\'s own default is 16 horizontal, 0 vertical. Set either to 0 to let the content reach all the way to that edge.',
+        type: 'dimension',
+        parse: (value: [string, string]) => {
+          const horizontal = Math.max(0, parseInt(value[0]) || 0)
+          const vertical = Math.max(0, parseInt(value[1]) || 0)
+          return [horizontal, vertical]
+        }
+      } as DimensionSetting,
       connectEdgesToArrowBase: { // Added by an LLM agent
         label: 'Connect edges to the arrow base',
         description: 'When enabled, an edge\'s line stops at the back of its arrow head instead of continuing on towards the node. Without this, a line that reaches a node at an angle runs through the arrow and attaches off-centre. Only affects triangle arrow heads.',
         type: 'boolean'
-      }
+      },
+      defaultNodeBorder: { // Added by an LLM agent
+        label: 'Default node border',
+        description: 'The border used by nodes that don\'t have a border style of their own set in the node popup.',
+        type: 'dropdown',
+        options: {
+          'default': 'Default (solid)',
+          'dashed': 'Dashed',
+          'dotted': 'Dotted',
+          'invisible': 'Invisible'
+        }
+      } as DropdownSetting,
     }
   },
   commandsFeatureEnabled: {
@@ -408,6 +456,11 @@ export const SETTINGS = {
     infoSection: 'native-like-file-search',
     children: { }
   },
+  dotMdFileSearchEnabled: { // Added by an LLM agent
+    label: 'Hidden ".md" files in file search',
+    description: 'When enabled, files named exactly ".md" — hidden dotfiles that Obsidian never indexes — show up in the canvas "Add note from vault" file search. Note: nodes created for such files cannot render their content, because the vault does not track them.',
+    children: { }
+  },
   autoFileNodeEdgesFeatureEnabled: {
     label: 'Auto file node edges',
     description: 'Automatically create edges between file nodes based their frontmatter links.',
@@ -429,6 +482,11 @@ export const SETTINGS = {
       showEdgesIntoDisabledPortals: {
         label: 'Show edges into disabled portals',
         description: 'When enabled, edges into disabled portals will be shown.',
+        type: 'boolean'
+      },
+      autoOpenSingleNodePortals: { // Added by an LLM agent
+        label: 'Auto-open single-node portals',
+        description: 'When enabled, a new file node linking to a canvas that contains only one node automatically opens as a portal.',
         type: 'boolean'
       }
     }
@@ -664,6 +722,12 @@ export const SETTINGS = {
   aspectRatioControlFeatureEnabled: {
     label: 'Aspect ratio control',
     description: 'Change the aspect ratio of nodes using the node popup menu or the context menu.',
+    children: { }
+  },
+  // Added by an LLM agent
+  nodeRotationFeatureEnabled: {
+    label: 'Node rotation',
+    description: 'Rotate nodes around their own center using the context menu (90° steps or a custom angle) or commands. Rotating a group or an open portal rigidly rotates all fully contained nodes with it. Also allows rotating just the content of a node in 90° steps (cardinal content rotation, propagates from groups/portals to the nodes within).',
     children: { }
   },
   variableBreakpointFeatureEnabled: {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,13 @@ export interface AdvancedCanvasPluginSettingsValues {
   minNodeSize: number
   maxNodeWidth: number
   disableFontSizeRelativeToZoom: boolean
+  wrapGroupLabels: boolean // Added by an LLM agent
+  hideGroupLabels: boolean // Added by an LLM agent
+  defaultGroupLabelSize: keyof typeof SETTINGS.general.children.defaultGroupLabelSize.options // Added by an LLM agent
+  defaultGroupOpacity: keyof typeof SETTINGS.general.children.defaultGroupOpacity.options // Added by an LLM agent
+  defaultEdgeWidth: keyof typeof SETTINGS.general.children.defaultEdgeWidth.options // Added by an LLM agent
+  defaultArrowSize: keyof typeof SETTINGS.general.children.defaultArrowSize.options // Added by an LLM agent
+  connectEdgesToArrowBase: boolean // Added by an LLM agent
 
   canvasMetadataCompatibilityEnabled: boolean
   enableSingleNodeLinks: boolean
@@ -85,6 +92,8 @@ export interface AdvancedCanvasPluginSettingsValues {
 
   focusModeFeatureEnabled: boolean
 
+  canvasFilterFeatureEnabled: boolean // Added by an LLM agent
+
   presentationFeatureEnabled: boolean
   showSetStartNodeInPopup: boolean
   defaultSlideDimensions: [number, number]
@@ -111,6 +120,11 @@ export interface AdvancedCanvasPluginSettingsValues {
 
   edgeSelectionEnabled: boolean
   selectEdgeByDirection: boolean
+
+  edgeLabelMarkdownEnabled: boolean // Added by an LLM agent
+  edgeLabelMarkdownRenderMode: keyof typeof SETTINGS.edgeLabelMarkdownEnabled.children.edgeLabelMarkdownRenderMode.options // Added by an LLM agent
+  edgeLabelMarkdownMaxWidth: number // Added by an LLM agent
+  edgeLabelMarkdownMaxHeight: number // Added by an LLM agent
 }
 
 export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
@@ -121,6 +135,13 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
   minNodeSize: 60,
   maxNodeWidth: -1,
   disableFontSizeRelativeToZoom: false,
+  wrapGroupLabels: true, // Added by an LLM agent
+  hideGroupLabels: false, // Added by an LLM agent
+  defaultGroupLabelSize: '1', // Added by an LLM agent
+  defaultGroupOpacity: 'default', // Added by an LLM agent
+  defaultEdgeWidth: '1', // Added by an LLM agent
+  defaultArrowSize: '1', // Added by an LLM agent
+  connectEdgesToArrowBase: false, // Added by an LLM agent
 
   canvasMetadataCompatibilityEnabled: true,
   enableSingleNodeLinks: true,
@@ -185,6 +206,8 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   focusModeFeatureEnabled: false,
 
+  canvasFilterFeatureEnabled: true, // Added by an LLM agent
+
   presentationFeatureEnabled: true,
   showSetStartNodeInPopup: false,
   defaultSlideDimensions: [1200, 675],
@@ -211,6 +234,11 @@ export const DEFAULT_SETTINGS_VALUES: AdvancedCanvasPluginSettingsValues = {
 
   edgeSelectionEnabled: false,
   selectEdgeByDirection: false,
+
+  edgeLabelMarkdownEnabled: false, // Added by an LLM agent
+  edgeLabelMarkdownRenderMode: 'embeds-only', // Added by an LLM agent
+  edgeLabelMarkdownMaxWidth: 400, // Added by an LLM agent
+  edgeLabelMarkdownMaxHeight: 300, // Added by an LLM agent
 }
 
 export const SETTINGS = {
@@ -268,6 +296,67 @@ export const SETTINGS = {
       disableFontSizeRelativeToZoom: {
         label: 'Disable font size relative to zoom',
         description: 'When enabled, the font size of e.g. group node titles and edge labels will not increase when zooming out.',
+        type: 'boolean'
+      },
+      wrapGroupLabels: { // Added by an LLM agent
+        label: 'Wrap group labels',
+        description: 'When enabled, a group label that is too long for the group will wrap onto multiple lines instead of being cut off.',
+        type: 'boolean'
+      },
+      hideGroupLabels: { // Added by an LLM agent
+        label: 'Hide group labels',
+        description: 'When enabled, group labels are hidden. Can be toggled with the "Toggle group label visibility" command.',
+        type: 'boolean'
+      },
+      defaultGroupLabelSize: { // Added by an LLM agent
+        label: 'Default group label size',
+        description: 'The label size used by groups that don\'t have a label size of their own set in the node popup.',
+        type: 'dropdown',
+        options: {
+          '0.75': 'Small (0.75x)',
+          '1': 'Default (1x)',
+          '1.5': 'Large (1.5x)',
+          '2': 'Huge (2x)',
+          '3': 'Giant (3x)'
+        }
+      } as DropdownSetting,
+      defaultGroupOpacity: { // Added by an LLM agent
+        label: 'Default group opacity',
+        description: 'The fill opacity used by groups that don\'t have an opacity of their own set in the node popup. 100% is a solid colour. Only the fill changes - the border and the label stay fully visible.',
+        type: 'dropdown',
+        options: {
+          'default': 'Default (7%)',
+          '0.25': '25%',
+          '0.5': '50%',
+          '0.75': '75%',
+          '1': 'Solid (100%)'
+        }
+      } as DropdownSetting,
+      defaultEdgeWidth: { // Added by an LLM agent
+        label: 'Default edge width',
+        description: 'The width used by edges that don\'t have an edge width of their own set in the edge popup.',
+        type: 'dropdown',
+        options: {
+          '0.5': 'Thin (0.5x)',
+          '1': 'Default (1x)',
+          '2': 'Thick (2x)',
+          '3': 'Extra Thick (3x)'
+        }
+      } as DropdownSetting,
+      defaultArrowSize: { // Added by an LLM agent
+        label: 'Default arrow size',
+        description: 'The arrow size used by edges that don\'t have an arrow size of their own set in the edge popup.',
+        type: 'dropdown',
+        options: {
+          '0.5': 'Small (0.5x)',
+          '1': 'Default (1x)',
+          '1.5': 'Large (1.5x)',
+          '2': 'Extra Large (2x)'
+        }
+      } as DropdownSetting,
+      connectEdgesToArrowBase: { // Added by an LLM agent
+        label: 'Connect edges to the arrow base',
+        description: 'When enabled, an edge\'s line stops at the back of its arrow head instead of continuing on towards the node. Without this, a line that reaches a node at an angle runs through the arrow and attaches off-centre. Only affects triangle arrow heads.',
         type: 'boolean'
       }
     }
@@ -574,7 +663,7 @@ export const SETTINGS = {
   },
   aspectRatioControlFeatureEnabled: {
     label: 'Aspect ratio control',
-    description: 'Change the aspect ratio of nodes using the context menu.',
+    description: 'Change the aspect ratio of nodes using the node popup menu or the context menu.',
     children: { }
   },
   variableBreakpointFeatureEnabled: {
@@ -654,10 +743,44 @@ export const SETTINGS = {
       }
     }
   },
+  // Added by an LLM agent
+  edgeLabelMarkdownEnabled: {
+    label: 'Markdown edge labels',
+    description: 'Render edge labels as markdown instead of plain text. Editing a label still shows its raw source. Use "Render mode" below to limit this to note embeds only.',
+    infoSection: 'markdown-edge-labels',
+    children: {
+      edgeLabelMarkdownRenderMode: {
+        label: 'Render mode',
+        description: 'What gets rendered. "Embeds only" renders a label that is nothing but note embeds - either bare (![[Note#^block]]) or wrapped in a ```sync code block - and leaves every other label as plain text.',
+        type: 'dropdown',
+        options: {
+          'embeds-only': 'Embeds only',
+          'full': 'Full markdown'
+        }
+      } as DropdownSetting,
+      edgeLabelMarkdownMaxWidth: {
+        label: 'Max label width',
+        description: 'The maximum width of a rendered edge label, in pixels.',
+        type: 'number',
+        parse: (value: string) => Math.max(50, parseInt(value) || 400)
+      },
+      edgeLabelMarkdownMaxHeight: {
+        label: 'Max label height',
+        description: 'The maximum height of a rendered edge label containing an embed, table or image, in pixels. Taller content scrolls.',
+        type: 'number',
+        parse: (value: string) => Math.max(50, parseInt(value) || 300)
+      }
+    }
+  },
   focusModeFeatureEnabled: {
     label: 'Focus mode',
     description: 'Focus on a single node and blur all other nodes.',
     infoSection: 'focus-mode',
+    children: { }
+  },
+  canvasFilterFeatureEnabled: { // Added by an LLM agent
+    label: 'Canvas filter',
+    description: 'Adds commands to temporarily hide the nodes and edges that don\'t match a filter (color, tag or connection to the selection). The filter is purely visual - nothing gets written to the canvas file.',
     children: { }
   },
 } as const satisfies {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -16,6 +16,7 @@
 @use "styles/floating-edge";
 @use "styles/focus-mode";
 @use "styles/canvas-filter"; // Added by an LLM agent
+@use "styles/rotate-node"; // Added by an LLM agent
 @use "styles/presentation";
 @use "styles/portals";
 @use "styles/embeds";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,7 +2,11 @@
 @use "styles/search-command";
 @use "styles/menu";
 @use "styles/node-styles";
+@use "styles/group-label-wrap"; // Added by an LLM agent
+@use "styles/group-label-visibility"; // Added by an LLM agent
 @use "styles/edge-styles";
+@use "styles/edge-label-markdown"; // Added by an LLM agent
+@use "styles/default-style-sizes"; // Added by an LLM agent
 @use "styles/node-templates";
 @use "styles/export";
 @use "styles/better-default-settings";
@@ -11,6 +15,7 @@
 @use "styles/collapsible-groups";
 @use "styles/floating-edge";
 @use "styles/focus-mode";
+@use "styles/canvas-filter"; // Added by an LLM agent
 @use "styles/presentation";
 @use "styles/portals";
 @use "styles/embeds";

--- a/src/styles/canvas-filter.scss
+++ b/src/styles/canvas-filter.scss
@@ -1,0 +1,7 @@
+/* Added by an LLM agent */
+/* Hides the nodes and edges that got filtered out by one of the canvas filter commands
+   (see `canvas-extensions/canvas-filter-canvas-extension.ts`). The class is only ever set at
+   runtime, so nothing of this ends up in the canvas file. */
+.canvas-wrapper .advanced-canvas-filtered-out {
+  display: none;
+}

--- a/src/styles/default-style-sizes.scss
+++ b/src/styles/default-style-sizes.scss
@@ -1,11 +1,13 @@
 /* Added by an LLM agent */
-/* Applies the configured default group label size, group opacity, edge width and arrow size to
-   every element that doesn't have a value of its own set in the node/edge popup.
+/* Applies the configured default group label size, group opacity, edge width, arrow size and
+   node border to every element that doesn't have a value of its own set in the node/edge popup.
 
    The data attributes are only set on the canvas wrapper while the corresponding setting isn't
-   at 1x (see default-style-sizes-canvas-extension.ts), so Obsidian's own sizing is untouched by
-   default. An element with an explicit size sets its own `--*-multiplier` (see node-styles.scss
-   and edge-styles.scss), which takes precedence over the default via the `var()` fallback. */
+   at its unchanged value (see default-style-sizes-canvas-extension.ts), so Obsidian's own styling
+   is untouched by default. An element with an explicit size sets its own `--*-multiplier` (see
+   node-styles.scss and edge-styles.scss), which takes precedence over the default via the `var()`
+   fallback; the node border rules instead guard with `:not([data-border])`, matching the
+   attribute the per-node border style is exposed as. */
 
 //#region Group label size
 .canvas-wrapper[data-default-group-label-size] {
@@ -23,6 +25,7 @@
 //#region Group opacity
 // 0.07 is Obsidian's own group tint - see the Group Opacity region in node-styles.scss
 .canvas-wrapper[data-default-group-opacity] {
+  &[data-default-group-opacity='0'] { --default-group-opacity: 0; }
   &[data-default-group-opacity='0.25'] { --default-group-opacity: 0.25; }
   &[data-default-group-opacity='0.5'] { --default-group-opacity: 0.5; }
   &[data-default-group-opacity='0.75'] { --default-group-opacity: 0.75; }
@@ -32,13 +35,21 @@
     background-color: color-mix(in oklch, var(--canvas-color) calc(var(--group-opacity, var(--default-group-opacity, 0.07)) * 100%), transparent);
   }
 }
+
+// Triplet `--canvas-color` builds - see the Group Opacity region in node-styles.scss
+.canvas-wrapper[data-canvas-color-format='triplet'][data-default-group-opacity] {
+  .canvas-node.canvas-node-group .canvas-node-container > .canvas-node-content {
+    background-color: rgba(var(--canvas-color), var(--group-opacity, var(--default-group-opacity, 0.07)));
+  }
+}
 //#endregion
 
 //#region Edge width
 .canvas-wrapper[data-default-edge-width] {
-  &[data-default-edge-width='0.5'] { --default-edge-width-multiplier: 0.5; }
   &[data-default-edge-width='2'] { --default-edge-width-multiplier: 2; }
-  &[data-default-edge-width='3'] { --default-edge-width-multiplier: 3; }
+  // Added by an LLM agent - the settings dropdown offers 4x and 8x but no rules set their multipliers
+  &[data-default-edge-width='4'] { --default-edge-width-multiplier: 4; }
+  &[data-default-edge-width='8'] { --default-edge-width-multiplier: 8; }
 
   .canvas-edges path.canvas-display-path {
     stroke-width: calc(2px * var(--zoom-multiplier) * var(--edge-width-multiplier, var(--default-edge-width-multiplier, 1)));
@@ -53,13 +64,87 @@
 
 //#region Arrow size
 .canvas-wrapper[data-default-arrow-size] {
-  &[data-default-arrow-size='0.5'] { --default-arrow-size-multiplier: 0.5; }
-  &[data-default-arrow-size='1.5'] { --default-arrow-size-multiplier: 1.5; }
   &[data-default-arrow-size='2'] { --default-arrow-size-multiplier: 2; }
+  &[data-default-arrow-size='3'] { --default-arrow-size-multiplier: 3; }
+  &[data-default-arrow-size='4'] { --default-arrow-size-multiplier: 4; }
 
   // Obsidian anchors the arrow at `center top`, so scaling keeps the tip on the node border
   .canvas-edges polygon.canvas-path-end {
     transform: scale(calc(var(--zoom-multiplier) * var(--arrow-size-multiplier, var(--default-arrow-size-multiplier, 1))));
+  }
+}
+//#endregion
+
+//#region Node border
+// Mirrors the per-node [data-border] rules in node-styles.scss, applied to every node without
+// its own border style. Nodes with an explicit per-node border keep it thanks to :not([data-border]).
+.canvas-wrapper[data-default-node-border] {
+  &[data-default-node-border='dashed'] .canvas-node:not([data-border]) .canvas-node-container {
+    box-shadow: none;
+    border-style: dashed;
+  }
+
+  &[data-default-node-border='dotted'] .canvas-node:not([data-border]) .canvas-node-container {
+    box-shadow: none;
+    border-style: dotted;
+  }
+
+  &[data-default-node-border='invisible'] .canvas-node:not([data-border]) {
+    box-shadow: none;
+
+    &:not(.is-focused):not(.is-selected) .canvas-node-container {
+      border-color: transparent !important;
+    }
+
+    .canvas-node-label {
+      display: none;
+    }
+
+    .canvas-node-container {
+      background-color: transparent;
+      box-shadow: none;
+    }
+  }
+}
+//#endregion
+
+//#region Card node padding
+// Independently adjustable horizontal/vertical inner padding of a card's (text/file node)
+// content, so the content can reach all the way to the node's edge on either axis. The two
+// custom properties are set directly (not gated behind a dataset attribute like the sections
+// above) because this is a continuous pixel value, not a discrete preset - see
+// default-style-sizes-canvas-extension.ts, which always sets them to [16, 0] at minimum,
+// reproducing Obsidian's own default padding exactly.
+.canvas-wrapper {
+  .canvas-node:not(.canvas-node-group) .canvas-node-content {
+    // Reading/editing view of markdown content (text nodes and .md file nodes)
+    .markdown-preview-view {
+      padding-left: var(--ac-card-padding-h, var(--size-4-4));
+      padding-right: var(--ac-card-padding-h, var(--size-4-4));
+      padding-top: var(--ac-card-padding-v, 0px);
+      padding-bottom: var(--ac-card-padding-v, 0px);
+    }
+
+    .markdown-source-view .cm-content {
+      padding-left: var(--ac-card-padding-h, var(--size-4-4));
+      padding-right: var(--ac-card-padding-h, var(--size-4-4));
+      padding-top: var(--ac-card-padding-v, 0px);
+      padding-bottom: var(--ac-card-padding-v, 0px);
+    }
+  }
+
+  // Obsidian centers short reading-view content inside a card with a pair of flex spacers
+  // (::before/::after on .markdown-preview-view, see app.css) instead of padding - each one
+  // grows up to `min(canvas-node-height * 0.1 - 3px, var(--size-4-4))` (up to 16px) regardless
+  // of the padding-top/bottom set above, which is why vertical padding could still look nonzero
+  // even after setting it to 0. Both min-height and max-height need overriding - CSS resolves a
+  // min/max conflict in favor of min-height, so overriding max-height alone (as tried first) had
+  // no visible effect once it dropped below the still-active default min-height.
+  .canvas-node:not(.canvas-node-group) .canvas-node-content.markdown-embed > .markdown-embed-content > .markdown-preview-view {
+    &::before, &::after {
+      min-height: var(--ac-card-padding-v, min(calc(var(--canvas-node-height) * 0.1 - 3px), var(--size-4-4)));
+      max-height: var(--ac-card-padding-v, var(--size-4-4));
+    }
   }
 }
 //#endregion

--- a/src/styles/default-style-sizes.scss
+++ b/src/styles/default-style-sizes.scss
@@ -1,0 +1,65 @@
+/* Added by an LLM agent */
+/* Applies the configured default group label size, group opacity, edge width and arrow size to
+   every element that doesn't have a value of its own set in the node/edge popup.
+
+   The data attributes are only set on the canvas wrapper while the corresponding setting isn't
+   at 1x (see default-style-sizes-canvas-extension.ts), so Obsidian's own sizing is untouched by
+   default. An element with an explicit size sets its own `--*-multiplier` (see node-styles.scss
+   and edge-styles.scss), which takes precedence over the default via the `var()` fallback. */
+
+//#region Group label size
+.canvas-wrapper[data-default-group-label-size] {
+  &[data-default-group-label-size='0.75'] { --default-group-label-size-multiplier: 0.75; }
+  &[data-default-group-label-size='1.5'] { --default-group-label-size-multiplier: 1.5; }
+  &[data-default-group-label-size='2'] { --default-group-label-size-multiplier: 2; }
+  &[data-default-group-label-size='3'] { --default-group-label-size-multiplier: 3; }
+
+  .canvas-node .canvas-group-label {
+    font-size: calc(1.5em * var(--group-label-size-multiplier, var(--default-group-label-size-multiplier, 1)));
+  }
+}
+//#endregion
+
+//#region Group opacity
+// 0.07 is Obsidian's own group tint - see the Group Opacity region in node-styles.scss
+.canvas-wrapper[data-default-group-opacity] {
+  &[data-default-group-opacity='0.25'] { --default-group-opacity: 0.25; }
+  &[data-default-group-opacity='0.5'] { --default-group-opacity: 0.5; }
+  &[data-default-group-opacity='0.75'] { --default-group-opacity: 0.75; }
+  &[data-default-group-opacity='1'] { --default-group-opacity: 1; }
+
+  .canvas-node.canvas-node-group .canvas-node-container > .canvas-node-content {
+    background-color: color-mix(in oklch, var(--canvas-color) calc(var(--group-opacity, var(--default-group-opacity, 0.07)) * 100%), transparent);
+  }
+}
+//#endregion
+
+//#region Edge width
+.canvas-wrapper[data-default-edge-width] {
+  &[data-default-edge-width='0.5'] { --default-edge-width-multiplier: 0.5; }
+  &[data-default-edge-width='2'] { --default-edge-width-multiplier: 2; }
+  &[data-default-edge-width='3'] { --default-edge-width-multiplier: 3; }
+
+  .canvas-edges path.canvas-display-path {
+    stroke-width: calc(2px * var(--zoom-multiplier) * var(--edge-width-multiplier, var(--default-edge-width-multiplier, 1)));
+  }
+
+  .canvas-edges g.is-focused path.canvas-display-path,
+  .canvas:not(.is-connecting) .canvas-edges g:hover path.canvas-display-path {
+    stroke-width: calc(5.5px * var(--zoom-multiplier) * var(--edge-width-multiplier, var(--default-edge-width-multiplier, 1)));
+  }
+}
+//#endregion
+
+//#region Arrow size
+.canvas-wrapper[data-default-arrow-size] {
+  &[data-default-arrow-size='0.5'] { --default-arrow-size-multiplier: 0.5; }
+  &[data-default-arrow-size='1.5'] { --default-arrow-size-multiplier: 1.5; }
+  &[data-default-arrow-size='2'] { --default-arrow-size-multiplier: 2; }
+
+  // Obsidian anchors the arrow at `center top`, so scaling keeps the tip on the node border
+  .canvas-edges polygon.canvas-path-end {
+    transform: scale(calc(var(--zoom-multiplier) * var(--arrow-size-multiplier, var(--default-arrow-size-multiplier, 1))));
+  }
+}
+//#endregion

--- a/src/styles/edge-label-markdown.scss
+++ b/src/styles/edge-label-markdown.scss
@@ -1,0 +1,62 @@
+/* Added by an LLM agent */
+/* Styling for edge labels that show rendered markdown instead of their raw source.
+   The classes are only present while the label is NOT being edited - during editing the label
+   falls back to the core plain-text look. */
+
+.canvas-path-label.ac-markdown-label {
+  /* The core label is a plain text box - rendered markdown needs block layout */
+  white-space: normal;
+  text-align: left;
+  max-width: var(--ac-markdown-label-max-width, 400px);
+
+  /* Let links, embeds and code blocks receive clicks (the extension stops those from
+     reaching the canvas' own label click handler) */
+  user-select: text;
+
+  /* Collapse the outer margins so the label isn't padded by its first/last block */
+  > :first-child { margin-top: 0; }
+  > :last-child { margin-bottom: 0; }
+
+  p {
+    margin-block: var(--size-2-2);
+  }
+
+  ul, ol {
+    margin-block: var(--size-2-2);
+    padding-inline-start: var(--size-4-4);
+  }
+
+  img,
+  .image-embed img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  pre {
+    margin-block: var(--size-2-2);
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+}
+
+/* Embeds, code block widgets, tables and images have no intrinsic width, so a shrink-to-fit
+   label collapses to a few pixels around them. Give the label a definite box instead, and cap
+   its height - an embedded note is otherwise free to be thousands of pixels tall. */
+.canvas-path-label.ac-markdown-label.ac-markdown-label-block {
+  width: var(--ac-markdown-label-max-width, 400px);
+  max-height: var(--ac-markdown-label-max-height, 300px);
+  overflow-y: auto;
+
+  .internal-embed,
+  .external-embed,
+  [class*="block-language-"] {
+    display: block;
+    width: 100%;
+  }
+}

--- a/src/styles/edge-styles.scss
+++ b/src/styles/edge-styles.scss
@@ -14,6 +14,65 @@
 }
 //#endregion
 
+//#region Invisible path (added by an LLM agent)
+// Hides the line and its arrow heads. The interaction path is left alone, so the edge can still be
+// clicked, dragged and re-styled where it runs - it just doesn't draw anything. The label (if any)
+// stays visible, mirroring how an invisible node border keeps the node's content.
+.canvas-edges {
+  path.canvas-display-path[data-path='invisible'],
+  [data-path='invisible'] polygon.canvas-path-end {
+    opacity: 0;
+  }
+
+  // Ghost the whole edge back in while it's selected, so an invisible edge can still be found.
+  // (`is-focused` comes from the edge highlight feature - hover below covers it when that's off.)
+  g.is-focused {
+    path.canvas-display-path[data-path='invisible'],
+    [data-path='invisible'] polygon.canvas-path-end {
+      opacity: 0.3;
+    }
+  }
+}
+
+// The arrow heads live in a second `.canvas-edges` svg, which isn't hovered along with the line -
+// so hovering only ghosts the line itself. Exports are unaffected: `.is-exporting` kills pointer
+// events, so nothing is ever hovered while exporting.
+.canvas:not(.is-connecting) .canvas-edges g:hover path.canvas-display-path[data-path='invisible'] {
+  opacity: 0.3;
+}
+//#endregion
+
+//#region Edge width
+.canvas-edges path[data-edge-width] {
+  &[data-edge-width='0.5'] { --edge-width-multiplier: 0.5; }
+  &[data-edge-width='2'] { --edge-width-multiplier: 2; }
+  &[data-edge-width='3'] { --edge-width-multiplier: 3; }
+}
+
+// Mirrors Obsidian's own selectors (+ the attribute) so the width multiplier also applies while focused/hovered
+.canvas-edges path.canvas-display-path[data-edge-width] {
+  stroke-width: calc(2px * var(--zoom-multiplier) * var(--edge-width-multiplier, 1));
+}
+
+.canvas-edges g.is-focused path.canvas-display-path[data-edge-width],
+.canvas:not(.is-connecting) .canvas-edges g:hover path.canvas-display-path[data-edge-width] {
+  stroke-width: calc(5.5px * var(--zoom-multiplier) * var(--edge-width-multiplier, 1));
+}
+//#endregion
+
+//#region Arrow size
+.canvas-edges [data-arrow-size] {
+  &[data-arrow-size='0.5'] { --arrow-size-multiplier: 0.5; }
+  &[data-arrow-size='1.5'] { --arrow-size-multiplier: 1.5; }
+  &[data-arrow-size='2'] { --arrow-size-multiplier: 2; }
+
+  // Obsidian anchors the arrow at `center top`, so scaling keeps the tip on the node border
+  polygon.canvas-path-end {
+    transform: scale(calc(var(--zoom-multiplier) * var(--arrow-size-multiplier, 1)));
+  }
+}
+//#endregion
+
 //#region Arrow
 .canvas-edges {
   [data-arrow='triangle-outline'], [data-arrow='diamond-outline'], [data-arrow='circle-outline'] {

--- a/src/styles/edge-styles.scss
+++ b/src/styles/edge-styles.scss
@@ -47,6 +47,9 @@
   &[data-edge-width='0.5'] { --edge-width-multiplier: 0.5; }
   &[data-edge-width='2'] { --edge-width-multiplier: 2; }
   &[data-edge-width='3'] { --edge-width-multiplier: 3; }
+  // Added by an LLM agent - the style config offers 4x and 8x but no rules set their multipliers
+  &[data-edge-width='4'] { --edge-width-multiplier: 4; }
+  &[data-edge-width='8'] { --edge-width-multiplier: 8; }
 }
 
 // Mirrors Obsidian's own selectors (+ the attribute) so the width multiplier also applies while focused/hovered
@@ -62,9 +65,9 @@
 
 //#region Arrow size
 .canvas-edges [data-arrow-size] {
-  &[data-arrow-size='0.5'] { --arrow-size-multiplier: 0.5; }
-  &[data-arrow-size='1.5'] { --arrow-size-multiplier: 1.5; }
   &[data-arrow-size='2'] { --arrow-size-multiplier: 2; }
+  &[data-arrow-size='3'] { --arrow-size-multiplier: 3; }
+  &[data-arrow-size='4'] { --arrow-size-multiplier: 4; }
 
   // Obsidian anchors the arrow at `center top`, so scaling keeps the tip on the node border
   polygon.canvas-path-end {

--- a/src/styles/group-label-visibility.scss
+++ b/src/styles/group-label-visibility.scss
@@ -1,0 +1,7 @@
+/* Added by an LLM agent */
+/* Hides all group labels while the `hideGroupLabels` setting is on (toggled by the
+   "Toggle group label visibility" command). The label stays visible while it is being
+   edited, so renaming a group still works with the labels hidden. */
+.canvas-wrapper[data-hide-group-labels="true"] .canvas-node .canvas-group-label:not(:focus) {
+  display: none;
+}

--- a/src/styles/group-label-wrap.scss
+++ b/src/styles/group-label-wrap.scss
@@ -1,0 +1,16 @@
+/* Added by an LLM agent */
+/* Obsidian keeps group labels on a single line and cuts them off with an ellipsis.
+   The label is limited to the width of the group (max-width: 100% / --zoom-multiplier),
+   so allowing it to wrap makes it break onto a new line instead. */
+.canvas-wrapper[data-wrap-group-labels="true"] .canvas-node:not([data-collapsed]) .canvas-group-label {
+  white-space: normal;
+  text-overflow: clip;
+
+  /* Break words that are longer than the group is wide - they could not wrap otherwise */
+  overflow-wrap: anywhere;
+
+  /* Shrink the label box to its longest wrapped line - the default shrink-to-fit width
+     stays at the maximum allowed width once the text wraps, leaving empty space next to
+     the text. Measured and set by group-label-wrap-canvas-extension.ts. */
+  width: var(--wrapped-group-label-width, auto);
+}

--- a/src/styles/menu.scss
+++ b/src/styles/menu.scss
@@ -3,6 +3,21 @@
   display: none;
 }
 
+/* Popup Menu */
+.clickable-icon.mod-text-option {
+  width: auto;
+  padding: 0 var(--size-4-2);
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-medium);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.clickable-icon.mod-text-option.is-active {
+  color: var(--text-on-accent);
+  background-color: var(--interactive-accent);
+}
+
 .canvas-control-item[data-toggled="true"] {
   background-color: var(--color-accent);
 

--- a/src/styles/node-styles.scss
+++ b/src/styles/node-styles.scss
@@ -263,9 +263,9 @@
   //#endregion
 
   //#region Group Opacity (added by an LLM agent)
-  // Obsidian tints a group with `color-mix(in oklch, var(--canvas-color) 7%, transparent)` on the
-  // content element - this replaces that 7% with the configured value, so 100% is a solid fill.
-  // Only the fill changes: the border and the label are left at full strength.
+  // Newer Obsidian builds tint a group with `color-mix(in oklch, var(--canvas-color) 7%, transparent)`
+  // on the content element - this replaces that 7% with the configured value, so 100% is a solid
+  // fill. Only the fill changes: the border and the label are left at full strength.
   &[data-group-opacity] {
     &[data-group-opacity='0.25'] { --group-opacity: 0.25; }
     &[data-group-opacity='0.5'] { --group-opacity: 0.5; }
@@ -275,6 +275,48 @@
     // Needs to outweigh Obsidian's own `.canvas-node.is-themed .canvas-node-content` rule
     .canvas-node-container > .canvas-node-content {
       background-color: color-mix(in oklch, var(--canvas-color) calc(var(--group-opacity, 0.07) * 100%), transparent);
+    }
+  }
+
+  // Older builds expose `--canvas-color` as an `r, g, b` triplet, which color-mix() can't
+  // take - the declaration above would be invalid at computed-value time and the fill would
+  // go transparent. They get an rgba() declaration instead, keyed on the wrapper attribute
+  // from default-style-sizes-canvas-extension.ts. Separate higher-specificity rule because a
+  // losing declaration never reaches computed-value time, while a winning-but-invalid one
+  // would compute to `unset`.
+  .canvas-wrapper[data-canvas-color-format='triplet'] &[data-group-opacity] {
+    .canvas-node-container > .canvas-node-content {
+      background-color: rgba(var(--canvas-color), var(--group-opacity, 0.07));
+    }
+  }
+  //#endregion
+
+  //#region Boxed Node Labels (added by an LLM agent)
+  // Mirrors Obsidian core's `.canvas-group-label` box styling - a rounded, colour-tinted
+  // background (solid when the node is themed) - onto regular file/text/link node labels,
+  // which core otherwise renders as plain text. Group nodes already get this from core, so
+  // they're excluded here to avoid doubling up.
+  .canvas-wrapper[data-boxed-node-labels='true'] &:not(.canvas-node-group) {
+    .canvas-node-label {
+      padding: var(--size-4-1) var(--size-4-2);
+      border-radius: var(--radius-s);
+      background-color: color-mix(in oklch, var(--canvas-color) 10%, transparent);
+      line-height: 1;
+    }
+
+    &.is-themed .canvas-node-label:not([contenteditable='true']) {
+      background-color: var(--canvas-color);
+    }
+  }
+
+  // Triplet `--canvas-color` builds - see the Group Opacity region above
+  .canvas-wrapper[data-canvas-color-format='triplet'][data-boxed-node-labels='true'] &:not(.canvas-node-group) {
+    .canvas-node-label {
+      background-color: rgba(var(--canvas-color), 0.1);
+    }
+
+    &.is-themed .canvas-node-label:not([contenteditable='true']) {
+      background-color: rgb(var(--canvas-color));
     }
   }
   //#endregion

--- a/src/styles/node-styles.scss
+++ b/src/styles/node-styles.scss
@@ -248,6 +248,37 @@
   }
   //#endregion
 
+  //#region Group Label Size (added by an LLM agent)
+  // The label already scales with the zoom level via a transform - this only multiplies its font size on top of that
+  &[data-group-label-size] {
+    &[data-group-label-size='0.75'] { --group-label-size-multiplier: 0.75; }
+    &[data-group-label-size='1.5'] { --group-label-size-multiplier: 1.5; }
+    &[data-group-label-size='2'] { --group-label-size-multiplier: 2; }
+    &[data-group-label-size='3'] { --group-label-size-multiplier: 3; }
+
+    .canvas-group-label {
+      font-size: calc(1.5em * var(--group-label-size-multiplier, 1));
+    }
+  }
+  //#endregion
+
+  //#region Group Opacity (added by an LLM agent)
+  // Obsidian tints a group with `color-mix(in oklch, var(--canvas-color) 7%, transparent)` on the
+  // content element - this replaces that 7% with the configured value, so 100% is a solid fill.
+  // Only the fill changes: the border and the label are left at full strength.
+  &[data-group-opacity] {
+    &[data-group-opacity='0.25'] { --group-opacity: 0.25; }
+    &[data-group-opacity='0.5'] { --group-opacity: 0.5; }
+    &[data-group-opacity='0.75'] { --group-opacity: 0.75; }
+    &[data-group-opacity='1'] { --group-opacity: 1; }
+
+    // Needs to outweigh Obsidian's own `.canvas-node.is-themed .canvas-node-content` rule
+    .canvas-node-container > .canvas-node-content {
+      background-color: color-mix(in oklch, var(--canvas-color) calc(var(--group-opacity, 0.07) * 100%), transparent);
+    }
+  }
+  //#endregion
+
   //#region Borders
   &[data-border='dashed'] .canvas-node-container {
     box-shadow: none;

--- a/src/styles/rotate-node.scss
+++ b/src/styles/rotate-node.scss
@@ -1,0 +1,48 @@
+// Added by an LLM agent
+// Content rotation for the node rotation feature.
+// The `data-content-rotation` attribute is set on the node element by the rotate node
+// extension (only when the `nodeRotationFeatureEnabled` setting is on). Its value is the
+// effective content rotation: the node's own plus the content rotation of every group/open
+// portal that fully contains it. The node's own rotation (and group rotations) are applied
+// to the node element's inline transform by `rotate-node-canvas-extension.ts` - these styles
+// only rotate the inner content.
+//
+// Known limitation: while editing a content-rotated text node, the inline editor
+// (iframe) may appear unrotated; the rotation shows in reading/preview.
+
+.canvas-node[data-content-rotation="180"] .canvas-node-container > .canvas-node-content {
+  transform: rotate(180deg);
+}
+
+// For 90°/270° the content box gets swapped (width <-> height) using Obsidian's own
+// CSS variables, is centered absolutely and then rotated. Text reflows in the swapped
+// box, so combined with the node transform the content fills the rotated frame.
+.canvas-node[data-content-rotation="90"],
+.canvas-node[data-content-rotation="270"] {
+  .canvas-node-container > .canvas-node-content {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+
+    width: var(--canvas-node-height);
+    height: var(--canvas-node-width);
+
+    // Make sure embeds (images, portals, iframes) fill the swapped box
+    img, video, iframe, .markdown-embed, .canvas-node-content-blocker {
+      width: 100%;
+      height: 100%;
+    }
+
+    img, video {
+      object-fit: contain;
+    }
+  }
+}
+
+.canvas-node[data-content-rotation="90"] .canvas-node-container > .canvas-node-content {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
+.canvas-node[data-content-rotation="270"] .canvas-node-container > .canvas-node-content {
+  transform: translate(-50%, -50%) rotate(270deg);
+}

--- a/src/utils/canvas-helper.ts
+++ b/src/utils/canvas-helper.ts
@@ -9,6 +9,8 @@ export interface MenuOption {
   id?: string
   label: string
   icon: string
+  /** If set, the option is rendered as a text button instead of an icon button (the label stays as the tooltip) */
+  text?: string
   callback?: () => void
 }
 
@@ -83,7 +85,12 @@ export default class CanvasHelper {
     const menuOptionElement = activeDocument.createElement('button')
     if (menuOption.id) menuOptionElement.id = menuOption.id
     menuOptionElement.classList.add('clickable-icon')
-    setIcon(menuOptionElement, menuOption.icon)
+
+    if (menuOption.text !== undefined) {
+      menuOptionElement.classList.add('mod-text-option')
+      menuOptionElement.textContent = menuOption.text
+    } else setIcon(menuOptionElement, menuOption.icon)
+
     setTooltip(menuOptionElement, menuOption.label, { placement: 'top' })
     menuOptionElement.addEventListener('click', () => menuOption.callback?.())
 

--- a/src/utils/edge-label-embed-helper.ts
+++ b/src/utils/edge-label-embed-helper.ts
@@ -1,0 +1,41 @@
+/* Added by an LLM agent */
+
+/** A single note embed on its own line, e.g. `![[Note#^block-id]]` or `![[Note|alias]]` */
+const EMBED_LINE_PATTERN = /^!\[\[[^[\]]+\]\]$/
+
+/**
+ * A fenced block whose info string is exactly `sync` (the `sync-embeds` plugin's block), e.g.
+ * ```sync
+ * ![[Note#^block-id{seamless:true}]]
+ * ```
+ * Backtick and tilde fences of three or more characters are matched; the closing fence has to
+ * repeat the opening one exactly. Group 2 is the fence body.
+ */
+const SYNC_FENCE_PATTERN = /^(`{3,}|~{3,})sync[ \t]*\n([\s\S]*?)\n?\1[ \t]*$/
+
+/**
+ * Whether a label consists of nothing but note embeds, and so is safe to render in
+ * "embeds only" mode. Accepted:
+ *
+ * - one or more bare `![[...]]` embeds, one per line
+ * - a single ` ```sync ` block whose body is one or more bare `![[...]]` embeds
+ *
+ * Anything else - prose, formatting, a bare link, an embed with text around it - is rejected,
+ * so the label keeps Obsidian's plain-text behaviour.
+ */
+export function isEmbedOnlyLabel(source: string): boolean {
+  const trimmed = source.trim()
+  if (trimmed.length === 0) return false
+
+  const fenceMatch = SYNC_FENCE_PATTERN.exec(trimmed)
+  return isEmbedLines(fenceMatch ? fenceMatch[2] : trimmed)
+}
+
+/** Whether every non-blank line of `content` is a bare embed (and there is at least one) */
+function isEmbedLines(content: string): boolean {
+  const lines = content.split('\n')
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+
+  return lines.length > 0 && lines.every(line => EMBED_LINE_PATTERN.test(line))
+}

--- a/src/utils/icons-helper.ts
+++ b/src/utils/icons-helper.ts
@@ -22,6 +22,19 @@ const CUSTOM_ICONS = {
   'border-dashed': `<path stroke="currentColor" fill="none" stroke-width="8.333" stroke-dasharray="13.7" d="M91.6667 45.8333v4.1667c0 2.0833-2.0833 4.1667-4.1667 4.1667H12.5c-2.0833 0-4.1667-2.0833-4.1667-4.1667v-4.1667"/>`,
   'border-dotted': `<path stroke="currentColor" fill="none" stroke-width="8.333" stroke-dasharray="8.7" d="M91.6667 45.8333v4.1667c0 2.0833-2.0833 4.1667-4.1667 4.1667H12.5c-2.0833 0-4.1667-2.0833-4.1667-4.1667v-4.1667"/>`,
 
+  // Group label size icons - "Aa" glyphs at increasing sizes (added by an LLM agent)
+  'label-size-small': `<text x="50" y="50" dominant-baseline="central" text-anchor="middle" font-size="40" font-weight="bold" fill="currentColor" stroke="none">Aa</text>`,
+  'label-size-default': `<text x="50" y="50" dominant-baseline="central" text-anchor="middle" font-size="55" font-weight="bold" fill="currentColor" stroke="none">Aa</text>`,
+  'label-size-large': `<text x="50" y="50" dominant-baseline="central" text-anchor="middle" font-size="70" font-weight="bold" fill="currentColor" stroke="none">Aa</text>`,
+  'label-size-huge': `<text x="50" y="50" dominant-baseline="central" text-anchor="middle" font-size="90" font-weight="bold" fill="currentColor" stroke="none">Aa</text>`,
+
+  // Group opacity icons - a square filled at the corresponding opacity (added by an LLM agent)
+  'opacity-default': `<rect x="12.5" y="12.5" width="75" height="75" rx="12.5" stroke="currentColor" stroke-width="8.333" fill="currentColor" fill-opacity="0.07"/>`,
+  'opacity-25':`<rect x="12.5" y="12.5" width="75" height="75" rx="12.5" stroke="currentColor" stroke-width="8.333" fill="currentColor" fill-opacity="0.25"/>`,
+  'opacity-50': `<rect x="12.5" y="12.5" width="75" height="75" rx="12.5" stroke="currentColor" stroke-width="8.333" fill="currentColor" fill-opacity="0.5"/>`,
+  'opacity-75': `<rect x="12.5" y="12.5" width="75" height="75" rx="12.5" stroke="currentColor" stroke-width="8.333" fill="currentColor" fill-opacity="0.75"/>`,
+  'opacity-100': `<rect x="12.5" y="12.5" width="75" height="75" rx="12.5" stroke="currentColor" stroke-width="8.333" fill="currentColor" fill-opacity="1"/>`,
+
   'path-solid': `<path stroke="currentColor" fill="none" stroke-width="8.5" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
   'path-dotted': `<path stroke="currentColor" fill="none" stroke-width="8.5" stroke-dasharray="8.8" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
   'path-short-dashed': `<path stroke="currentColor" fill="none" stroke-width="8.5" stroke-dasharray="15" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
@@ -35,6 +48,16 @@ const CUSTOM_ICONS = {
   'arrow-diamond-outline': `<path stroke="currentColor" stroke-width="8.5" fill="none" d="M 50 0 L 100 50 L 50 100 L 0 50 Z"/>`,
   'arrow-circle': `<circle stroke="currentColor" fill="currentColor" cx="50" cy="50" r="45"/>`,
   'arrow-circle-outline': `<circle stroke="currentColor" stroke-width="8.5" fill="none" cx="50" cy="50" r="45"/>`,
+
+  'edge-width-thin': `<path stroke="currentColor" fill="none" stroke-width="4" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
+  'edge-width-default': `<path stroke="currentColor" fill="none" stroke-width="8.5" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
+  'edge-width-thick': `<path stroke="currentColor" fill="none" stroke-width="17" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
+  'edge-width-extra-thick': `<path stroke="currentColor" fill="none" stroke-width="25.5" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
+
+  'arrow-size-small': `<path stroke="currentColor" fill="currentColor" d="M 39 38 L 61 50 L 39 62 Z"/>`,
+  'arrow-size-default': `<path stroke="currentColor" fill="currentColor" d="M 33 30 L 68 50 L 33 70 Z"/>`,
+  'arrow-size-large': `<path stroke="currentColor" fill="currentColor" d="M 24 20 L 79 50 L 24 80 Z"/>`,
+  'arrow-size-extra-large': `<path stroke="currentColor" fill="currentColor" d="M 15 10 L 90 50 L 15 90 Z"/>`,
 
   'pathfinding-method-bezier': `<path stroke="currentColor" fill="none" stroke-width="8.5" d="M37.5 79.1667h35.4167a14.5833 14.5833 90 000-29.1667h-45.8333a14.5833 14.5833 90 010-29.1667H62.5"/>`,
   'pathfinding-method-square': `<path stroke="currentColor" fill="none" stroke-width="8.5" d="M72.9167 79.1667 72.9167 50 27.0833 50 27.0833 20.8333"/>`,


### PR DESCRIPTION
i use llms to do all of it.

Off the top of my head:
- group opacity
- node rotation (this works with portals)
- node label resizing
- markdown rendering inside of edge labels (i use this to point to blocks or headings within existing notes)
- edge resizing
- node label wrapping
- added default values to things like the card padding in the plugin settings
- some other shit i probably forgot about

yeah.